### PR TITLE
Provide image which is based on Debian 10/buster

### DIFF
--- a/Dockerfile-jdk11-buster
+++ b/Dockerfile-jdk11-buster
@@ -1,0 +1,38 @@
+# The MIT License
+#
+#  Copyright (c) 2015-2017, CloudBees, Inc.
+#
+#  Permission is hereby granted, free of charge, to any person obtaining a copy
+#  of this software and associated documentation files (the "Software"), to deal
+#  in the Software without restriction, including without limitation the rights
+#  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+#  copies of the Software, and to permit persons to whom the Software is
+#  furnished to do so, subject to the following conditions:
+#
+#  The above copyright notice and this permission notice shall be included in
+#  all copies or substantial portions of the Software.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+#  THE SOFTWARE.
+
+ARG version=4.0.1-1-jdk11-buster
+FROM jenkins/slave:$version
+
+ARG version
+MAINTAINER Oleg Nenashev <o.v.nenashev@gmail.com>
+LABEL Description="This is a base image, which allows connecting Jenkins agents via JNLP protocols" Vendor="Jenkins project" Version="$version"
+
+ARG user=jenkins
+
+USER root
+COPY jenkins-agent /usr/local/bin/jenkins-agent
+RUN chmod +x /usr/local/bin/jenkins-agent &&\
+    ln -s /usr/local/bin/jenkins-agent /usr/local/bin/jenkins-slave
+USER ${user}
+
+ENTRYPOINT ["jenkins-slave"]

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,9 @@ IMAGE_NAME:=jenkins4eval/jnlp-slave
 IMAGE_ALPINE:=${IMAGE_NAME}:alpine
 IMAGE_DEBIAN:=${IMAGE_NAME}:test
 IMAGE_JDK11:=${IMAGE_NAME}:jdk11
+IMAGE_JDK11_BUSTER:=${IMAGE_NAME}:jdk11-buster
 
-build: build-alpine build-debian build-jdk11
+build: build-alpine build-debian build-jdk11 build-jdk11-buster
 
 build-alpine:
 	docker build -t ${IMAGE_ALPINE} --file Dockerfile-alpine .
@@ -16,13 +17,16 @@ build-debian:
 build-jdk11:
 	docker build -t ${IMAGE_JDK11} --file Dockerfile-jdk11 .
 
+build-jdk11-buster:
+	docker build -t ${IMAGE_JDK11_BUSTER} --file Dockerfile-jdk11-buster .
+
 bats:
 # The lastest version is v1.1.0
 	@if [ ! -d bats-core ]; then git clone https://github.com/bats-core/bats-core.git; fi
 	@git -C bats-core reset --hard c706d1470dd1376687776bbe985ac22d09780327
 
 .PHONY: test
-test: test-alpine test-debian test-jdk11
+test: test-alpine test-debian test-jdk11 test-jdk11-buster
 
 .PHONY: test-alpine
 test-alpine: bats
@@ -35,3 +39,7 @@ test-debian: bats
 .PHONY: test-jdk11
 test-jdk11: bats
 	@FLAVOR=jdk11 bats-core/bin/bats tests/tests.bats
+
+.PHONY: test-jdk11-buster
+test-jdk11-buster: bats
+	@FLAVOR=jdk11-buster bats-core/bin/bats tests/tests.bats

--- a/tests/tests.bats
+++ b/tests/tests.bats
@@ -15,6 +15,12 @@ then
   JDK=11
   SLAVE_IMAGE+=":jdk11"
   SLAVE_CONTAINER+="-jdk11"
+elif [[ "${FLAVOR}" = "jdk11-buster" ]]
+then
+  DOCKERFILE+="-jdk11-buster"
+  JDK=11
+  SLAVE_IMAGE+=":jdk11-buster"
+  SLAVE_CONTAINER+="-jdk11-buster"
 else
   DOCKERFILE+="-alpine"
   SLAVE_IMAGE+=":alpine"


### PR DESCRIPTION
Requires https://github.com/jenkinsci/docker-slave/pull/106 to be merged and the image to be available (the version might need change after the image has been published).