### PR TITLE
Updated the Windows images parent versions

### DIFF
--- a/Dockerfile-windows
+++ b/Dockerfile-windows
@@ -20,7 +20,7 @@
 #  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 #  THE SOFTWARE.
 
-ARG version=latest-windows
+ARG version=latest
 FROM jenkins/agent:$version
 
 ARG version

--- a/Dockerfile-windows-jdk11
+++ b/Dockerfile-windows-jdk11
@@ -20,7 +20,7 @@
 #  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 #  THE SOFTWARE.
 
-FROM jenkins/agent:latest-windows-jdk11
+FROM jenkins/agent:latest-jdk11
 MAINTAINER Alex Earl <slide.o.mix@gmail.com>
 LABEL Description="This is a base image, which allows connecting Jenkins agents via JNLP protocols on Windows" Vendor="Jenkins Project" Version="3.29"
 


### PR DESCRIPTION
The `jenkins/agent` images have changed their tagging structure (as of [this commit](https://github.com/jenkinsci/docker-slave/commit/90acccaacfc75f39fd09ec74abac92eed13cf94c)), so the version tags that were previously referenced no longer exist. This PR updates both Windows images (JDK8 and JDK11) to use the new tags.

See the Configurations section for the `jenkins/agent` images: https://github.com/jenkinsci/docker-slave#configurations