### PR TITLE
Fix Windows image publishing for tagged releases

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -41,7 +41,7 @@ pipeline {
                             }
 
                             def tagName = "${env.TAG_NAME}"
-                            if(tagName ==~ '\\d\\.\\d') {
+                            if(tagName =~ /\d(\.\d)+(-\d+)?/) {
                                 // we need to build and publish the tagged version
                                 infra.withDockerCredentials {
                                     powershell "& ./make.ps1 -PushVersions -VersionTag $tagName publish"


### PR DESCRIPTION
Groovy has two match like operators, `==~` which requires an exact match, and `=~` which is a find operator. Update the check to use the find operator.