### PR TITLE
Add openjdk11-alpine Dockerfile

### DIFF
--- a/11/alpine/Dockerfile
+++ b/11/alpine/Dockerfile
@@ -1,0 +1,37 @@
+# The MIT License
+#
+#  Copyright (c) 2015-2020, CloudBees, Inc.
+#
+#  Permission is hereby granted, free of charge, to any person obtaining a copy
+#  of this software and associated documentation files (the "Software"), to deal
+#  in the Software without restriction, including without limitation the rights
+#  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+#  copies of the Software, and to permit persons to whom the Software is
+#  furnished to do so, subject to the following conditions:
+#
+#  The above copyright notice and this permission notice shall be included in
+#  all copies or substantial portions of the Software.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+#  THE SOFTWARE.
+
+ARG version=latest-alpine-jdk11
+FROM jenkins/agent:$version
+
+ARG version
+LABEL Description="This is a base image, which allows connecting Jenkins agents via JNLP protocols" Vendor="Jenkins project" Version="$version"
+
+ARG user=jenkins
+
+USER root
+COPY jenkins-agent /usr/local/bin/jenkins-agent
+RUN chmod +x /usr/local/bin/jenkins-agent &&\
+    ln -s /usr/local/bin/jenkins-agent /usr/local/bin/jenkins-slave
+USER ${user}
+
+ENTRYPOINT ["jenkins-agent"]

--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,11 @@ ROOT:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 
 IMAGE_NAME:=jenkins4eval/jnlp-slave
 IMAGE_ALPINE:=${IMAGE_NAME}:alpine
+IMAGE_ALPINE_JDK11:=${IMAGE_NAME}:alpine-jdk11
 IMAGE_DEBIAN:=${IMAGE_NAME}:test
 IMAGE_JDK11:=${IMAGE_NAME}:jdk11
 
-build: build-alpine build-debian build-jdk11
+build: build-alpine build-debian build-jdk11 build-jdk11-alpine
 
 build-alpine:
 	cp -f jenkins-agent 8/alpine/
@@ -19,13 +20,18 @@ build-jdk11:
 	cp -f jenkins-agent 11/debian/
 	docker build -t ${IMAGE_JDK11} 11/debian
 
+build-jdk11-alpine:
+	cp -f jenkins-agent 11/alpine/
+	docker build -t ${IMAGE_ALPINE} 11/alpine
+
+
 bats:
 # The lastest version is v1.1.0
 	@if [ ! -d bats-core ]; then git clone https://github.com/bats-core/bats-core.git; fi
 	@git -C bats-core reset --hard c706d1470dd1376687776bbe985ac22d09780327
 
-.PHONY: test test-alpine test-debian test-jdk11
-test: test-alpine test-debian test-jdk11
+.PHONY: test test-alpine test-debian test-jdk11 test-jdk11-alpine
+test: test-alpine test-debian test-jdk11 test-jdk11-alpine
 
 test-alpine: bats
 	@FOLDER="8/alpine" bats-core/bin/bats tests/tests.bats
@@ -35,3 +41,6 @@ test-debian: bats
 
 test-jdk11: bats
 	@FOLDER="11/debian" bats-core/bin/bats tests/tests.bats
+
+test-jdk11-alpine: bats
+	@FOLDER="11/alpine" bats-core/bin/bats tests/tests.bats


### PR DESCRIPTION
This PR adds a openjdk11-alpine Dockerfile which uses
jenkins/agent:latest-alpine-jdk11 as its base.