### PR TITLE
the /EXPIRE (sic) flag on `net user` does not set the password expiry

### DIFF
--- a/11/nanoserver-1809/Dockerfile
+++ b/11/nanoserver-1809/Dockerfile
@@ -33,7 +33,8 @@ RUN $output = net users ; `
     if(-not ($output -match $env:user)) { `
         Write-Host 'user does not exist?' ; `
         net user $env:user /add /expire:never /passwordreq:no ; `
-        net localgroup Administrators /add $env:user `
+        net localgroup Administrators /add $env:user ; `
+        wmic useraccount WHERE Name=$env:user set PasswordExpires=false; `
     }
 
 COPY jenkins-agent.ps1 C:/ProgramData/Jenkins

--- a/11/windowsservercore-1809/Dockerfile
+++ b/11/windowsservercore-1809/Dockerfile
@@ -32,7 +32,8 @@ RUN $output = net users ; `
     if(-not ($output -match $env:user)) { `
         Write-Host 'user does not exist?' ; `
         net user $env:user /add /expire:never /passwordreq:no ; `
-        net localgroup Administrators /add $env:user `
+        net localgroup Administrators /add $env:user ; `
+        wmic useraccount WHERE Name=$env:user set PasswordExpires=false; `
     }
 
 COPY jenkins-agent.ps1 C:/ProgramData/Jenkins

--- a/8/nanoserver-1809/Dockerfile
+++ b/8/nanoserver-1809/Dockerfile
@@ -32,7 +32,8 @@ RUN $output = net users ; `
     if(-not ($output -match $env:user)) { `
         Write-Host 'user does not exist?' ; `
         net user $env:user /add /expire:never /passwordreq:no ; `
-        net localgroup Administrators /add $env:user `
+        net localgroup Administrators /add $env:user ; `
+        wmic useraccount WHERE Name=$env:user set PasswordExpires=false; `
     }
 
 COPY jenkins-agent.ps1 C:/ProgramData/Jenkins

--- a/8/windowsservercore-1809/Dockerfile
+++ b/8/windowsservercore-1809/Dockerfile
@@ -32,7 +32,8 @@ RUN $output = net users ; `
     if(-not ($output -match $env:user)) { `
         Write-Host 'user does not exist?' ; `
         net user $env:user /add /expire:never /passwordreq:no ; `
-        net localgroup Administrators /add $env:user `
+        net localgroup Administrators /add $env:user ; `
+        wmic useraccount WHERE Name=$env:user set PasswordExpires=false; `
     }
 
 COPY jenkins-agent.ps1 C:/ProgramData/Jenkins


### PR DESCRIPTION
Rather `/EXPIRE` (sic) sets the account expiry so the account itself will expire ([details](https://www.top-password.com/blog/differences-between-user-account-expiration-and-password-expiration/))

this means that the image is DOA after the default password expiration
duration.

Add a call to `wmic` to set the password to never expire

fixes #173 


