### PR TITLE
Fix #180 - "jdk8" appears twice in one of the tags

### DIFF
--- a/make.ps1
+++ b/make.ps1
@@ -22,7 +22,7 @@ if(![String]::IsNullOrWhiteSpace($env:DOCKERHUB_ORGANISATION)) {
 $builds = @{
     'jdk8' = @{
         'Folder' = '8\windowsservercore-1809';
-        'Tags' = @( "windowsservercore-1809", "jdk8-windowsservercore-1809-jdk8" );
+        'Tags' = @( "windowsservercore-1809", "jdk8-windowsservercore-1809" );
     };
     'jdk11' = @{
         'Folder' = '11\windowsservercore-1809';


### PR DESCRIPTION
Removed the extra "jdk8" from the tag name.