### PR TITLE
Pass $VERSION correctly in windows tests

### DIFF
--- a/make.ps1
+++ b/make.ps1
@@ -101,13 +101,13 @@ if($Target -eq "test") {
     if(![System.String]::IsNullOrWhiteSpace($Build) -and $builds.ContainsKey($Build)) {
         $env:FOLDER = $builds[$Build]['Folder']
         $env:VERSION = $DockerAgentVersion
-        Invoke-Pester -Path tests -EnableExit
+        Invoke-Pester -Path tests -EnableExit -OutputFile ".\target\${env:FOLDER}\junit-results.xml" -OutputFormat JUnitXml
         Remove-Item env:\FOLDER
     } else {
         foreach($b in $builds.Keys) {
             $env:FOLDER = $builds[$b]['Folder']
             $env:VERSION = $DockerAgentVersion
-            Invoke-Pester -Path tests -EnableExit
+            Invoke-Pester -Path tests -EnableExit -OutputFile ".\target\${env:FOLDER}\junit-results.xml" -OutputFormat JUnitXml
             Remove-Item env:\FOLDER
         }
     }


### PR DESCRIPTION
make.ps1 : pass test results to Jenkins UI

inboundAgent.test.ps1:  

1.  The build created 'jenkins/inbound-agent' images and the tests created 'jenkins-inbound-agent' images, and I've often confused them. Moreover the 'jenkins-inbound-agent' might have overloaded build-args.  Including 'test' in the image name makes it  more understandable that image is for test purposes.
 
2. It was also not simmetric that the the 'nanoserver' branch had the branch name in the tag, others branches shared the 'latest' tag. Now it tags every branches.

**3. Pass $VERSION build argument correctly.**

4. Create containers with modifed build arguments with modified tags.

The version string passing change (line 45 -> 54) solves the bug alone.
The other improvements might be also good if you agree with them.
