### PR TITLE
change entrypoint to absolute path

### DIFF
--- a/11/alpine/Dockerfile
+++ b/11/alpine/Dockerfile
@@ -35,4 +35,4 @@ RUN chmod +x /usr/local/bin/jenkins-agent &&\
     ln -s /usr/local/bin/jenkins-agent /usr/local/bin/jenkins-slave
 USER ${user}
 
-ENTRYPOINT ["jenkins-agent"]
+ENTRYPOINT ["/usr/local/bin/jenkins-agent"]

--- a/11/debian/Dockerfile
+++ b/11/debian/Dockerfile
@@ -34,4 +34,4 @@ RUN chmod +x /usr/local/bin/jenkins-agent &&\
     ln -s /usr/local/bin/jenkins-agent /usr/local/bin/jenkins-slave
 USER ${user}
 
-ENTRYPOINT ["jenkins-agent"]
+ENTRYPOINT ["/usr/local/bin/jenkins-agent"]

--- a/8/alpine/Dockerfile
+++ b/8/alpine/Dockerfile
@@ -34,4 +34,4 @@ RUN chmod +x /usr/local/bin/jenkins-agent &&\
     ln -s /usr/local/bin/jenkins-agent /usr/local/bin/jenkins-slave
 USER ${user}
 
-ENTRYPOINT ["jenkins-agent"]
+ENTRYPOINT ["/usr/local/bin/jenkins-agent"]

--- a/8/debian/Dockerfile
+++ b/8/debian/Dockerfile
@@ -34,4 +34,4 @@ RUN chmod +x /usr/local/bin/jenkins-agent &&\
     ln -s /usr/local/bin/jenkins-agent /usr/local/bin/jenkins-slave
 USER ${user}
 
-ENTRYPOINT ["jenkins-agent"]
+ENTRYPOINT ["/usr/local/bin/jenkins-agent"]


### PR DESCRIPTION
Entrypoint changed on Linux based Dockerfiles. 

The need for this was discovered while working on https://issues.jenkins.io/browse/INFRA-2879, specifically https://github.com/jenkinsci/jnlp-agents/blob/master/alpine/Dockerfile is now being tested by container structure tests.