### PR TITLE
Do not prevent execution if the single argument is an option

### DIFF
--- a/jenkins-agent
+++ b/jenkins-agent
@@ -36,9 +36,9 @@
 #                              the agent skips connecting to an HTTP(S) port for connection info.
 # * JENKINS_PROTOCOLS:         Specify the remoting protocols to attempt when instanceIdentity is provided.
 
-if [ $# -eq 1 ]; then
+if [ $# -eq 1 ] && [ "${1#-}" == "$1" ] ; then
 
-	# if `docker run` only has one arguments, we assume user is running alternate command like `bash` to inspect the image
+	# if `docker run` only has one arguments and it is not an option as `-help`, we assume user is running alternate command like `bash` to inspect the image
 	exec "$@"
 
 else


### PR DESCRIPTION
This prevents such kind of error:

```sh-session
$ docker run jenkins/inbound-agent -disableHttpsCertValidation
/usr/local/bin/jenkins-agent: 42: exec: -disableHttpsCertValidation: not found
```