### PR TITLE
feat(#223):Docker-in-Docker support

### DIFF
--- a/8/debian-dind/Dockerfile
+++ b/8/debian-dind/Dockerfile
@@ -1,0 +1,71 @@
+# The MIT License
+#
+#  Copyright (c) 2015-2017, CloudBees, Inc.
+#
+#  Permission is hereby granted, free of charge, to any person obtaining a copy
+#  of this software and associated documentation files (the "Software"), to deal
+#  in the Software without restriction, including without limitation the rights
+#  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+#  copies of the Software, and to permit persons to whom the Software is
+#  furnished to do so, subject to the following conditions:
+#
+#  The above copyright notice and this permission notice shall be included in
+#  all copies or substantial portions of the Software.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+#  THE SOFTWARE.
+
+ARG version=4.6-2
+FROM jenkins/agent:$version
+
+ARG version
+LABEL Description="This is a base image, which allows connecting Jenkins agents via JNLP protocols" Vendor="Jenkins project" Version="$version"
+
+ARG user=jenkins
+
+USER root
+COPY jenkins-agent /usr/local/bin/jenkins-agent
+RUN chmod +x /usr/local/bin/jenkins-agent &&\
+    ln -s /usr/local/bin/jenkins-agent /usr/local/bin/jenkins-slave
+
+
+ARG dockerComposeLinuxComponentVersion='1.28.5'
+ARG dockerLinuxComponentVersion='5:19.03.14~3-0~debian'
+
+
+RUN apt-get update -y &&\
+    apt-get install -y \
+    apt-transport-https \
+    ca-certificates \
+    curl \
+    gnupg \
+    lsb-release 
+
+RUN curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
+
+RUN echo \
+  "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/debian \
+  $(lsb_release -cs) stable" |  tee /etc/apt/sources.list.d/docker.list > /dev/null
+
+RUN apt-get update -y  &&\
+    apt-get install -y docker-ce=${dockerLinuxComponentVersion}-$(lsb_release -cs) docker-ce-cli=${dockerLinuxComponentVersion}-$(lsb_release -cs) containerd.io=1.2.13-2 \
+    systemd && \
+    systemctl disable docker
+
+
+
+RUN  curl -SL "https://github.com/docker/compose/releases/download/${dockerComposeLinuxComponentVersion}/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose && chmod +x /usr/local/bin/docker-compose && \
+    apt-get clean && rm -rf /var/lib/apt/lists/* && \
+    usermod -aG docker ${user} && \
+    echo "${user} ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
+
+VOLUME /var/lib/docker
+
+USER ${user}
+
+ENTRYPOINT ["/usr/local/bin/jenkins-agent"]

--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,10 @@ IMAGE_NAME:=jenkins4eval/jnlp-slave
 IMAGE_ALPINE:=${IMAGE_NAME}:alpine
 IMAGE_ALPINE_JDK11:=${IMAGE_NAME}:alpine-jdk11
 IMAGE_DEBIAN:=${IMAGE_NAME}:test
+IMAGE_DEBIAN_DIND:=${IMAGE_NAME}:test-dind
 IMAGE_JDK11:=${IMAGE_NAME}:jdk11
 
-build: build-alpine build-debian build-jdk11 build-jdk11-alpine
+build: build-alpine build-debian build-debian-dind build-jdk11 build-jdk11-alpine
 
 build-alpine:
 	cp -f jenkins-agent 8/alpine/
@@ -15,6 +16,10 @@ build-alpine:
 build-debian:
 	cp -f jenkins-agent 8/debian/
 	docker build -t ${IMAGE_DEBIAN} 8/debian
+
+build-debian-dind:
+	cp -f jenkins-agent 8/debian-dind/
+	docker build -t ${IMAGE_DEBIAN_DIND} 8/debian-dind
 
 build-jdk11:
 	cp -f jenkins-agent 11/debian/

--- a/jenkins-agent
+++ b/jenkins-agent
@@ -113,5 +113,13 @@ else
 	#TODO: Handle the case when the command-line and Environment variable contain different values.
 	#It is fine it blows up for now since it should lead to an error anyway.
 
+	# docker in docker enabled base on DOCKER_IN_DOCKER variable
+	if [ "$DOCKER_IN_DOCKER" = "start" ] ; then
+	sudo rm /var/run/docker.pid 2>/dev/null
+	sudo service docker start
+	echo "Docker daemon started"
+	service docker status
+	fi
+
 	exec $JAVA_BIN $JAVA_OPTS -cp /usr/share/jenkins/agent.jar hudson.remoting.jnlp.Main -headless $TUNNEL $URL $WORKDIR $WEB_SOCKET $DIRECT $PROTOCOLS $INSTANCE_IDENTITY $OPT_JENKINS_SECRET $OPT_JENKINS_AGENT_NAME "$@"
 fi


### PR DESCRIPTION
<!-- Please describe your pull request here. -->


- [x] Feature Request: Docker-in-Docker support(#223)
- [x] Docker-in-Docker support
- [x] adding docker in docker support  now docker commands can be run inside the Jenkins docker-inbound-agent  
- [x] Feature Request: Docker-in-Docker support #223
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] tested locally  :
`docker run -v docker_volumes:/var/lib/docker  --privileged -e DOCKER_IN_DOCKER=start  --net jenkins  --init jenkins/inbound-agent:dind  -url http://jenkins:8080 -workDir=/home/jenkins/agent $SECRET debian`

![image](https://user-images.githubusercontent.com/52507296/112039380-46651a00-8b44-11eb-8f67-bb46cddc102e.png)

<!--
Put an `x` into the [ ] to show you have filled the information
-->

[test-build.log](https://github.com/jenkinsci/docker-inbound-agent/files/6184600/test-build.log)
