### PR TITLE
Adding a position parameters aside of switch parameters in jenkins-agent.ps1 to fix windows jenkinsci/amazon-ecs-plugin

### DIFF
--- a/jenkins-agent.ps1
+++ b/jenkins-agent.ps1
@@ -24,8 +24,8 @@
 Param(
     $Cmd = '', # this is only used when docker run has one arg positional arg
     $Url = $( if([System.String]::IsNullOrWhiteSpace($Cmd) -and [System.String]::IsNullOrWhiteSpace($env:JENKINS_URL)) { throw ("Url is required") } else { '' } ),
-    $Secret = $( if([System.String]::IsNullOrWhiteSpace($Cmd) -and [System.String]::IsNullOrWhiteSpace($env:JENKINS_SECRET)) { throw ("Secret is required") } else { '' } ),
-    $Name = $( if([System.String]::IsNullOrWhiteSpace($Cmd) -and [System.String]::IsNullOrWhiteSpace($env:JENKINS_AGENT_NAME)) { throw ("Name is required") } else { '' } ),
+    [Parameter(Position=0)]$Secret = $( if([System.String]::IsNullOrWhiteSpace($Cmd) -and [System.String]::IsNullOrWhiteSpace($env:JENKINS_SECRET)) { throw ("Secret is required") } else { '' } ),
+    [Parameter(Position=1)]$Name = $( if([System.String]::IsNullOrWhiteSpace($Cmd) -and [System.String]::IsNullOrWhiteSpace($env:JENKINS_AGENT_NAME)) { throw ("Name is required") } else { '' } ),
     $Tunnel = '',
     $WorkDir = '',
     [switch] $WebSocket = $false,


### PR DESCRIPTION
There are two bug reports opened in jenkinsci/amazon-ecs-plugin:

```
https://github.com/jenkinsci/amazon-ecs-plugin/issues/155
https://github.com/jenkinsci/amazon-ecs-plugin/issues/225
```

Nature of the issue related to different call syntax for Windows and Linux agents:
Linux agent:
docker run --init jenkins/inbound-agent -url http://jenkins-server:port <secret> <agent name>

Windows agent:
docker run jenkins/inbound-agent:windowsservercore-1809 -Url http://jenkins-server:port **-Secret** <secret> **-Name** <agent name>

Unfortunately amazon-ecs-plugin in a kind of unsupported state, therefore I decided to improve docker-inbound-agent the way that it will become bit more compatible. I implemented a possibility to have a secret as a first positional parameter and name as a second positional parameter.

I tested the code and it works as a charm. Will be good to have it in upstream

- [ x ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [ x ] Ensure that the pull request title represents the desired changelog entry
- [ x ] Please describe what you did
- [ x ] Link to relevant issues in GitHub or Jira
- [ x ] Link to relevant pull requests, esp. upstream and downstream changes
- [ x ] Ensure you have provided tests - that demonstrates feature works or fixes the issue