### PR TITLE
Specify JENKINS_JAVA_BIN to run the agent using a specific JRE

### DIFF
--- a/jenkins-agent
+++ b/jenkins-agent
@@ -24,6 +24,7 @@
 
 # Usage jenkins-agent.sh [options] -url http://jenkins [SECRET] [AGENT_NAME]
 # Optional environment variables :
+# * JENKINS_JAVA_BIN : Java executable to use instead of the default in PATH or obtained from JAVA_HOME
 # * JENKINS_TUNNEL : HOST:PORT for a tunnel to route TCP traffic to jenkins host, when jenkins can't be directly accessed over network
 # * JENKINS_URL : alternate jenkins URL
 # * JENKINS_SECRET : agent secret, if not set as an argument
@@ -85,10 +86,14 @@ else
 		INSTANCE_IDENTITY="-instanceIdentity $JENKINS_INSTANCE_IDENTITY"
 	fi
 
-	# if java home is defined, use it
-	JAVA_BIN="java"
-	if [ "$JAVA_HOME" ]; then
-		JAVA_BIN="$JAVA_HOME/bin/java"
+	if [ "$JENKINS_JAVA_BIN" ]; then
+		JAVA_BIN="$JENKINS_JAVA_BIN"
+	else
+		# if java home is defined, use it
+		JAVA_BIN="java"
+		if [ "$JAVA_HOME" ]; then
+			JAVA_BIN="$JAVA_HOME/bin/java"
+		fi
 	fi
 
 	# if both required options are defined, do not pass the parameters

--- a/jenkins-agent.ps1
+++ b/jenkins-agent.ps1
@@ -32,11 +32,13 @@ Param(
     $DirectConnection = '',
     $InstanceIdentity = '',
     $Protocols = '',
+    $JenkinsJavaBin = '',
     $JavaHome = $env:JAVA_HOME
 )
 
 # Usage jenkins-agent.ps1 [options] -Url http://jenkins -Secret [SECRET] -Name [AGENT_NAME]
 # Optional environment variables :
+# * JENKINS_JAVA_BIN : Java executable to use instead of the default in PATH or obtained from JAVA_HOME
 # * JENKINS_TUNNEL : HOST:PORT for a tunnel to route TCP traffic to jenkins host, when jenkins can't be directly accessed over network
 # * JENKINS_URL : alternate jenkins URL
 # * JENKINS_SECRET : agent secret, if not set as an argument
@@ -55,8 +57,9 @@ if(![System.String]::IsNullOrWhiteSpace($Cmd)) {
 } else {
     $AgentArguments = @("-cp", "C:/ProgramData/Jenkins/agent.jar", "hudson.remoting.jnlp.Main", "-headless")
 
-    # this maps the variable name from th CmdletBinding to environment variables
+    # this maps the variable name from the CmdletBinding to environment variables
     $ParamMap = @{
+        'JenkinsJavaBin' = 'JENKINS_JAVA_BIN';
         'Tunnel' = 'JENKINS_TUNNEL';
         'Url' = 'JENKINS_URL';
         'Secret' = 'JENKINS_SECRET';
@@ -123,10 +126,14 @@ if(![System.String]::IsNullOrWhiteSpace($Cmd)) {
     # parameters to agent.jar
     $AgentArguments += @($Secret, $Name)
 
-    # if java home is defined, use it
-    $JAVA_BIN="java.exe"
-    if(![System.String]::IsNullOrWhiteSpace($JavaHome)) {
-        $JAVA_BIN="$JavaHome/bin/java.exe"
+    if(![System.String]::IsNullOrWhiteSpace($JenkinsJavaBin)) {
+        $JAVA_BIN = $JenkinsJavaBin
+    } else {
+        # if java home is defined, use it
+        $JAVA_BIN = "java.exe"
+        if (![System.String]::IsNullOrWhiteSpace($JavaHome)) {
+            $JAVA_BIN = "$JavaHome/bin/java.exe"
+        }
     }
 
     #TODO: Handle the case when the command-line and Environment variable contain different values.


### PR DESCRIPTION
This allows to use a specific JRE to run the Jenkins agent, differing
from the one that is available through PATH or JAVA_HOME.

<!-- Please describe your pull request here. -->

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
