### PR TITLE
Remoting 4.11.2

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -37,11 +37,11 @@ variable "JENKINS_REPO" {
 }
 
 variable "REMOTING_VERSION" {
-  default = "4.11"
+  default = "4.11.2"
 }
 
 variable "BUILD_NUMBER" {
-  default = "6"
+  default = "1"
 }
 
 variable "ON_TAG" {

--- a/make.ps1
+++ b/make.ps1
@@ -4,8 +4,8 @@ Param(
     [String] $Target = "build",
     [String] $AdditionalArgs = '',
     [String] $Build = '',
-    [String] $VersionTag = '4.11-1',
-    [String] $DockerAgentVersion = '4.11-1',
+    [String] $VersionTag = '4.11.2-1',
+    [String] $DockerAgentVersion = '4.11.2-1',
     [switch] $PushVersions = $false
 )
 


### PR DESCRIPTION
## Remoting 4.11.2

Thanks to @timja and @Hellspan for the docker-agent update to 4.11.2
