### PR TITLE
Add Java 17 alpine

### DIFF
--- a/17/alpine/Dockerfile
+++ b/17/alpine/Dockerfile
@@ -1,6 +1,6 @@
 # The MIT License
 #
-#  Copyright (c) 2015-2020, CloudBees, Inc.
+#  Copyright (c) 2015-2020, CloudBees, Inc. and other Jenkins contributors
 #
 #  Permission is hereby granted, free of charge, to any person obtaining a copy
 #  of this software and associated documentation files (the "Software"), to deal

--- a/17/alpine/Dockerfile
+++ b/17/alpine/Dockerfile
@@ -35,4 +35,6 @@ RUN chmod +x /usr/local/bin/jenkins-agent &&\
     ln -s /usr/local/bin/jenkins-agent /usr/local/bin/jenkins-slave
 USER ${user}
 
+ENV JENKINS_ENABLE_FUTURE_JAVA=true
+
 ENTRYPOINT ["/usr/local/bin/jenkins-agent"]

--- a/17/alpine/Dockerfile
+++ b/17/alpine/Dockerfile
@@ -1,0 +1,38 @@
+# The MIT License
+#
+#  Copyright (c) 2015-2020, CloudBees, Inc.
+#
+#  Permission is hereby granted, free of charge, to any person obtaining a copy
+#  of this software and associated documentation files (the "Software"), to deal
+#  in the Software without restriction, including without limitation the rights
+#  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+#  copies of the Software, and to permit persons to whom the Software is
+#  furnished to do so, subject to the following conditions:
+#
+#  The above copyright notice and this permission notice shall be included in
+#  all copies or substantial portions of the Software.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+#  THE SOFTWARE.
+
+#TODO(oleg_nenashev): Does it also need an update?
+ARG version=latest-alpine-jdk17
+FROM jenkins/agent:$version
+
+ARG version
+LABEL Description="This is a base image, which allows connecting Jenkins agents via JNLP protocols" Vendor="Jenkins project" Version="$version"
+
+ARG user=jenkins
+
+USER root
+COPY ../../jenkins-agent /usr/local/bin/jenkins-agent
+RUN chmod +x /usr/local/bin/jenkins-agent &&\
+    ln -s /usr/local/bin/jenkins-agent /usr/local/bin/jenkins-slave
+USER ${user}
+
+ENTRYPOINT ["/usr/local/bin/jenkins-agent"]

--- a/17/debian/Dockerfile
+++ b/17/debian/Dockerfile
@@ -12,4 +12,6 @@ RUN chmod +x /usr/local/bin/jenkins-agent &&\
     ln -s /usr/local/bin/jenkins-agent /usr/local/bin/jenkins-slave
 USER ${user}
 
+ENV JENKINS_ENABLE_FUTURE_JAVA=true
+
 ENTRYPOINT ["/usr/local/bin/jenkins-agent"]

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -87,9 +87,9 @@ target "alpine_jdk17" {
     version = "${REMOTING_VERSION}-${AGENT_IMAGE_BUILD_NUMBER}-alpine-jdk17"
   }
   tags = [
-    equal(ON_TAG, "true") ? "${REGISTRY}/${JENKINS_REPO}:${REMOTING_VERSION}-${BUILD_NUMBER}-alpine-jdk17": "",
-    "${REGISTRY}/${JENKINS_REPO}:alpine-jdk17",
-    "${REGISTRY}/${JENKINS_REPO}:latest-alpine-jdk17",
+    equal(ON_TAG, "true") ? "${REGISTRY}/${JENKINS_REPO}:${REMOTING_VERSION}-${BUILD_NUMBER}-alpine-jdk17-preview": "",
+    "${REGISTRY}/${JENKINS_REPO}:alpine-jdk17-preview",
+    "${REGISTRY}/${JENKINS_REPO}:latest-alpine-jdk17-preview",
   ]
   platforms = ["linux/amd64"]
 }

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -2,6 +2,7 @@ group "linux" {
   targets = [
     "alpine_jdk8",
     "alpine_jdk11",
+    "alpine_jdk17",
     "debian_jdk8",
     "debian_jdk11",
     "debian_jdk17",
@@ -75,6 +76,20 @@ target "alpine_jdk11" {
     "${REGISTRY}/${JENKINS_REPO}:alpine-jdk11",
     "${REGISTRY}/${JENKINS_REPO}:latest-alpine",
     "${REGISTRY}/${JENKINS_REPO}:latest-alpine-jdk11",
+  ]
+  platforms = ["linux/amd64"]
+}
+
+target "alpine_jdk17" {
+  dockerfile = "17/alpine/Dockerfile"
+  context = "."
+  args = {
+    version = "${REMOTING_VERSION}-${AGENT_IMAGE_BUILD_NUMBER}-alpine-jdk17"
+  }
+  tags = [
+    equal(ON_TAG, "true") ? "${REGISTRY}/${JENKINS_REPO}:${REMOTING_VERSION}-${BUILD_NUMBER}-alpine-jdk17": "",
+    "${REGISTRY}/${JENKINS_REPO}:alpine-jdk17",
+    "${REGISTRY}/${JENKINS_REPO}:latest-alpine-jdk17",
   ]
   platforms = ["linux/amd64"]
 }

--- a/jenkins-agent
+++ b/jenkins-agent
@@ -118,5 +118,18 @@ else
 	#TODO: Handle the case when the command-line and Environment variable contain different values.
 	#It is fine it blows up for now since it should lead to an error anyway.
 
-	exec $JAVA_BIN $JAVA_OPTS -cp /usr/share/jenkins/agent.jar hudson.remoting.jnlp.Main -headless $TUNNEL $URL $WORKDIR $WEB_SOCKET $DIRECT $PROTOCOLS $INSTANCE_IDENTITY $OPT_JENKINS_SECRET $OPT_JENKINS_AGENT_NAME "$@"
+        FUTURE_OPTS=""
+        if [ "$JENKINS_ENABLE_FUTURE_JAVA" ] ; then
+                FUTURE_OPTS="--add-opens java.base/java.lang=ALL-UNNAMED
+                        --add-opens java.base/java.io=ALL-UNNAMED
+                        --add-opens java.base/java.util=ALL-UNNAMED
+                        --add-opens java.base/java.util.concurrent=ALL-UNNAMED
+                        --add-opens java.base/java.lang.reflect=ALL-UNNAMED
+                        --add-opens java.base/java.text=ALL-UNNAMED
+                        --add-opens java.desktop/java.awt.font=ALL-UNNAMED
+                "
+        fi
+
+        exec $JAVA_BIN ${FUTURE_OPTS} $JAVA_OPTS -cp /usr/share/jenkins/agent.jar hudson.remoting.jnlp.Main -headless $TUNNEL $URL $WORKDIR $WEB_SOCKET $DIRECT $PROTOCOLS $INSTANCE_IDENTITY $OPT_JENKINS_SECRET $OPT_JENKINS_AGENT_NAME "$@"
+
 fi


### PR DESCRIPTION
adding jdk17 for alpine

tests performed locally

- `make test-alpine_jdk17`
- `java -version`

```
$ docker run jenkins/agent:alpine-jdk17 java -version
openjdk version "17.0.1" 2021-10-19
OpenJDK Runtime Environment (build 17.0.1+12-alpine-r0)
OpenJDK 64-Bit Server VM (build 17.0.1+12-alpine-r0, mixed mode)
```

- [x] Make sure you are opening from a topic/feature/bugfix branch (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
