### PR TITLE
Allow the use of multiple arguments

### DIFF
--- a/jenkins-agent
+++ b/jenkins-agent
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 # The MIT License
 #
@@ -37,9 +37,9 @@
 #                              the agent skips connecting to an HTTP(S) port for connection info.
 # * JENKINS_PROTOCOLS:         Specify the remoting protocols to attempt when instanceIdentity is provided.
 
-if [ $# -eq 1 ] && [ "${1#-}" = "$1" ] ; then
+if [ "${1:0:1}" != '-' ]; then
 
-	# if `docker run` only has one arguments and it is not an option as `-help`, we assume user is running alternate command like `bash` to inspect the image
+	# if `docker run`'s first argument does not look like a flag, we assume the user is running an alternate command like `bash` to inspect the image
 	exec "$@"
 
 else


### PR DESCRIPTION
I want to run local builds of [jenkinsci/packaging](https://github.com/jenkinsci/packaging) inside of the same Docker image used in production, [jenkins-infra/docker-packaging](https://github.com/jenkins-infra/docker-packaging). But when I try to do this with e.g. `docker run […] --rm […] jenkinsciinfra/packaging:latest […] /bin/bash -c 'make clean'` I get:

```
"-c" is not a valid option
java -jar agent.jar [options...] <secret key> <agent name>
[…]
```

Looking at the code, I see that the code path to pass through options to the entrypoint is only doing so if there is one argument and it doesn't start with a dash. My use case `/bin/bash -c 'make clean'` doesn't start with a dash, but it is three arguments, so it doesn't get passed through, and I'd like it to.

Looking at the [`Dockerfile` best practices for `ENTRYPOINT`](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#entrypoint) I found a reference to the [Postgres Official Image](https://github.com/docker-library/postgres/blob/a83005b407ee6d810413500d8a041c957fb10cf0/docker-entrypoint.sh#L299-L302) entrypoint, which has a particularly nice trick: check if the first argument looks like a flag, and if so run the daemon; otherwise, pass through the arguments.

This PR applies the same trick to this repository. I verified that it gets my use case to work. Since production use cases always pass a flag in as the first argument, this shouldn't affect them.

Note that the implementation requires switching from `dash(1)` to `bash(1)`.