### PR TITLE
Specify JENKINS_JAVA_OPTS to pass JVM options that apply to the agent only

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ To run a Docker container with [Work Directory](https://github.com/jenkinsci/rem
 
 Optional environment variables:
 
+* `JENKINS_JAVA_BIN`: Path to Java executable to use instead of the default in PATH or obtained from JAVA_HOME
 * `JENKINS_JAVA_OPTS` : Java Options to use for the remoting process, otherwise obtained from JAVA_OPTS
 * `JENKINS_URL`: url for the Jenkins server, can be used as a replacement to `-url` option, or to set alternate jenkins URL
 * `JENKINS_TUNNEL`: (`HOST:PORT`) connect to this agent host and port instead of Jenkins server, assuming this one do route TCP traffic to Jenkins master. Useful when when Jenkins runs behind a load balancer, reverse proxy, etc.
@@ -45,6 +46,9 @@ Optional environment variables:
 * `JENKINS_AGENT_NAME`: agent name, if not set as an argument
 * `JENKINS_AGENT_WORKDIR`: agent work directory, if not set by optional parameter `-workDir`
 * `JENKINS_WEB_SOCKET`: `true` if the connection should be made via WebSocket rather than TCP
+* `JENKINS_DIRECT_CONNECTION`: (`HOST:PORT`) Connect directly to this TCP agent port, skipping the HTTP(S) connection parameter download.
+* `JENKINS_INSTANCE_IDENTITY`: The base64 encoded InstanceIdentity byte array of the Jenkins master. When this is set, the agent skips connecting to an HTTP(S) port for connection info.
+* `JENKINS_PROTOCOLS`: Specify the remoting protocols to attempt when `JENKINS_INSTANCE_IDENTITY` is provided.
 
 ## Configuration specifics
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ To run a Docker container with [Work Directory](https://github.com/jenkinsci/rem
 
 Optional environment variables:
 
+* `JENKINS_JAVA_OPTS` : Java Options to use for the remoting process, otherwise obtained from JAVA_OPTS
 * `JENKINS_URL`: url for the Jenkins server, can be used as a replacement to `-url` option, or to set alternate jenkins URL
 * `JENKINS_TUNNEL`: (`HOST:PORT`) connect to this agent host and port instead of Jenkins server, assuming this one do route TCP traffic to Jenkins master. Useful when when Jenkins runs behind a load balancer, reverse proxy, etc.
 * `JENKINS_SECRET`: agent secret, if not set as an argument

--- a/jenkins-agent
+++ b/jenkins-agent
@@ -25,6 +25,7 @@
 # Usage jenkins-agent.sh [options] -url http://jenkins [SECRET] [AGENT_NAME]
 # Optional environment variables :
 # * JENKINS_JAVA_BIN : Java executable to use instead of the default in PATH or obtained from JAVA_HOME
+# * JENKINS_JAVA_OPTS : Java Options to use for the remoting process, otherwise obtained from JAVA_OPTS
 # * JENKINS_TUNNEL : HOST:PORT for a tunnel to route TCP traffic to jenkins host, when jenkins can't be directly accessed over network
 # * JENKINS_URL : alternate jenkins URL
 # * JENKINS_SECRET : agent secret, if not set as an argument
@@ -96,6 +97,15 @@ else
 		fi
 	fi
 
+	if [ "$JENKINS_JAVA_OPTS" ]; then
+		JAVA_OPTIONS="$JENKINS_JAVA_OPTS"
+	else
+		# if JAVA_OPTS is defined, use it
+		if [ "$JAVA_OPTS" ]; then
+			JAVA_OPTIONS="$JAVA_OPTS"
+		fi
+	fi
+
 	# if both required options are defined, do not pass the parameters
 	OPT_JENKINS_SECRET=""
 	if [ -n "$JENKINS_SECRET" ]; then
@@ -130,6 +140,6 @@ else
                 "
         fi
 
-        exec $JAVA_BIN ${FUTURE_OPTS} $JAVA_OPTS -cp /usr/share/jenkins/agent.jar hudson.remoting.jnlp.Main -headless $TUNNEL $URL $WORKDIR $WEB_SOCKET $DIRECT $PROTOCOLS $INSTANCE_IDENTITY $OPT_JENKINS_SECRET $OPT_JENKINS_AGENT_NAME "$@"
+        exec $JAVA_BIN ${FUTURE_OPTS} $JAVA_OPTIONS -cp /usr/share/jenkins/agent.jar hudson.remoting.jnlp.Main -headless $TUNNEL $URL $WORKDIR $WEB_SOCKET $DIRECT $PROTOCOLS $INSTANCE_IDENTITY $OPT_JENKINS_SECRET $OPT_JENKINS_AGENT_NAME "$@"
 
 fi


### PR DESCRIPTION
As discussed recently with @jtnord: there is no way to correctly tune **ONLY** the JVM arguments used by the Jenkins agent. `JAVA_OPTS` can be used, but this environment variable may then be consumed by other tools that use java.. 

This enhancement provide the ability to pass JVM Arguments that applies ONLY to the agent process and nothing else using an optional environment variable `JENKINS_JAVA_OPTS`. It preserved compatibility with `JAVA_OPTS`. Though `JENKINS_JAVA_OPTS` can be used and takes precedence.

Note: Also added missing documentation about optional environment variables.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue