### PR TITLE
Remove `--add-opens` directives on Java 17

### DIFF
--- a/17/alpine/Dockerfile
+++ b/17/alpine/Dockerfile
@@ -35,6 +35,4 @@ RUN chmod +x /usr/local/bin/jenkins-agent &&\
     ln -s /usr/local/bin/jenkins-agent /usr/local/bin/jenkins-slave
 USER ${user}
 
-ENV JENKINS_ENABLE_FUTURE_JAVA=true
-
 ENTRYPOINT ["/usr/local/bin/jenkins-agent"]

--- a/17/debian/Dockerfile
+++ b/17/debian/Dockerfile
@@ -12,6 +12,4 @@ RUN chmod +x /usr/local/bin/jenkins-agent &&\
     ln -s /usr/local/bin/jenkins-agent /usr/local/bin/jenkins-slave
 USER ${user}
 
-ENV JENKINS_ENABLE_FUTURE_JAVA=true
-
 ENTRYPOINT ["/usr/local/bin/jenkins-agent"]

--- a/jenkins-agent
+++ b/jenkins-agent
@@ -128,18 +128,6 @@ else
 	#TODO: Handle the case when the command-line and Environment variable contain different values.
 	#It is fine it blows up for now since it should lead to an error anyway.
 
-        FUTURE_OPTS=""
-        if [ "$JENKINS_ENABLE_FUTURE_JAVA" ] ; then
-                FUTURE_OPTS="--add-opens java.base/java.lang=ALL-UNNAMED
-                        --add-opens java.base/java.io=ALL-UNNAMED
-                        --add-opens java.base/java.util=ALL-UNNAMED
-                        --add-opens java.base/java.util.concurrent=ALL-UNNAMED
-                        --add-opens java.base/java.lang.reflect=ALL-UNNAMED
-                        --add-opens java.base/java.text=ALL-UNNAMED
-                        --add-opens java.desktop/java.awt.font=ALL-UNNAMED
-                "
-        fi
-
-        exec $JAVA_BIN ${FUTURE_OPTS} $JAVA_OPTIONS -cp /usr/share/jenkins/agent.jar hudson.remoting.jnlp.Main -headless $TUNNEL $URL $WORKDIR $WEB_SOCKET $DIRECT $PROTOCOLS $INSTANCE_IDENTITY $OPT_JENKINS_SECRET $OPT_JENKINS_AGENT_NAME "$@"
+        exec $JAVA_BIN $JAVA_OPTIONS -cp /usr/share/jenkins/agent.jar hudson.remoting.jnlp.Main -headless $TUNNEL $URL $WORKDIR $WEB_SOCKET $DIRECT $PROTOCOLS $INSTANCE_IDENTITY $OPT_JENKINS_SECRET $OPT_JENKINS_AGENT_NAME "$@"
 
 fi


### PR DESCRIPTION
See recent discussion in #207. I was thinking about moving the `--add-opens` lines from https://github.com/jenkinsci/docker-inbound-agent/blob/516b518fc78066d7f6ea271b548e32eb7e6db4fc/jenkins-agent#L133-L139 to an `<Add-Opens>` entry in Remoting's `MANIFEST.MF` (as in jenkinsci/jenkins#6356), so first I wanted to reproduce the stack trace mentioned in #207 when there are no `--add-opens` directives. But I was unable to reproduce #207 on the latest Jenkins weekly (Jenkins 2.338, Remoting 4.13, XStream 1.4.19) when running controller and agent on Java 17 (OpenJDK) both with and without WebSocket mode without any `--add-opens` directives or custom entries in `MANIFEST.MF` on the agent. I was able to run a Pipeline job to completion on the agent and was even able to successfully run `new hudson.util.XStream2()` in the agent's script console.

Based on the above, I conclude that these `--add-opens` directives aren't needed anymore, so this PR removes them. I am not 100% sure about this, and this could cause a regression on Java 17 if these are needed, but I think that is an acceptable risk. The alternative would be to move the existing entries to `<Add-Opens>` in `MANIFEST.MF` in Remoting. That would clean up the code, but without any way to reproduce #207, I have no way of testing that change either. And I think the current status quo is the worst of all three options.