### PR TITLE
Use jenkins/agent:4.13-2

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -24,9 +24,9 @@ group "linux-ppc64le" {
   targets = []
 }
 
-# update this to use a newer build number for jenkins/docker-agent image
+# update this to use a newer build number of the jenkins/agent image
 variable "AGENT_IMAGE_BUILD_NUMBER" {
-  default = "1"
+  default = "2"
 }
 
 variable "REGISTRY" {
@@ -41,8 +41,9 @@ variable "REMOTING_VERSION" {
   default = "4.13"
 }
 
+# Used in the tag pushed to the jenkins/inbound-agent image
 variable "BUILD_NUMBER" {
-  default = "1"
+  default = "2"
 }
 
 variable "ON_TAG" {


### PR DESCRIPTION
## Use `jenkins/agent:4.13-2`

https://github.com/jenkinsci/docker-agent/releases/tag/4.13-2 lists:

* fix: enable long paths for git in Windows images (#239) @lemeurherve

* Use git lfs 3.1.4, not 3.1.2 (#246) @MarkEWaite
* Use Java 17.0.2_8, not 17_35 on Nanoserver (#245) @MarkEWaite
* Use git 2.35.3 for Windows (#244) @MarkEWaite
* Use remoting 4.13, not 4.12 (#243) @MarkEWaite
* Use Alpine 3.15.4, not 3.15.0 (#242) @MarkEWaite
* Bump debian from bullseye-20220228 to bullseye-20220328 in /11/bullseye (#237, #240) @dependabot
* Bump debian from bullseye-20220228 to bullseye-20220328 in /8/bullseye (#236, #241) @dependabot

## Checklist

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
