### PR TITLE
Now builds also for `linux/arm/v7`.

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -113,7 +113,7 @@ target "debian_jdk11" {
   dockerfile = "11/debian/Dockerfile"
   context = "."
   args = {
-    version = "${REMOTING_VERSION}.${AGENT_IMAGE_BUILD_NUMBER}-jdk11"
+    version = "${REMOTING_VERSION}-${AGENT_IMAGE_BUILD_NUMBER}-jdk11"
   }
   tags = [
     equal(ON_TAG, "true") ? "${REGISTRY}/${JENKINS_REPO}:${REMOTING_VERSION}-${BUILD_NUMBER}": "",

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -129,7 +129,7 @@ target "debian_jdk17" {
   dockerfile = "17/debian/Dockerfile"
   context = "."
   args = {
-    version = "${REMOTING_VERSION}.${AGENT_IMAGE_BUILD_NUMBER}-jdk17-preview"
+    version = "${REMOTING_VERSION}-${AGENT_IMAGE_BUILD_NUMBER}-jdk17-preview"
   }
   tags = [
     equal(ON_TAG, "true") ? "${REGISTRY}/${JENKINS_REPO}:${REMOTING_VERSION}-${BUILD_NUMBER}-jdk17-preview": "",

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -26,7 +26,7 @@ group "linux-ppc64le" {
 
 # update this to use a newer build number of the jenkins/agent image
 variable "AGENT_IMAGE_BUILD_NUMBER" {
-  default = "2-1"
+  default = "1"
 }
 
 variable "REGISTRY" {

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -38,7 +38,7 @@ variable "JENKINS_REPO" {
 }
 
 variable "REMOTING_VERSION" {
-  default = "4.13"
+  default = "4.13.2"
 }
 
 # Used in the tag pushed to the jenkins/inbound-agent image, no need to update this the pipeline will change it

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -26,7 +26,7 @@ group "linux-ppc64le" {
 
 # update this to use a newer build number of the jenkins/agent image
 variable "AGENT_IMAGE_BUILD_NUMBER" {
-  default = "2"
+  default = "2-1"
 }
 
 variable "REGISTRY" {
@@ -113,7 +113,7 @@ target "debian_jdk11" {
   dockerfile = "11/debian/Dockerfile"
   context = "."
   args = {
-    version = "${REMOTING_VERSION}-${AGENT_IMAGE_BUILD_NUMBER}-jdk11"
+    version = "${REMOTING_VERSION}.${AGENT_IMAGE_BUILD_NUMBER}-jdk11"
   }
   tags = [
     equal(ON_TAG, "true") ? "${REGISTRY}/${JENKINS_REPO}:${REMOTING_VERSION}-${BUILD_NUMBER}": "",
@@ -122,19 +122,19 @@ target "debian_jdk11" {
     "${REGISTRY}/${JENKINS_REPO}:latest",
     "${REGISTRY}/${JENKINS_REPO}:latest-jdk11",
   ]
-  platforms = ["linux/amd64", "linux/arm64", "linux/s390x"]
+  platforms = ["linux/amd64", "linux/arm64", "linux/arm/v7", "linux/s390x"]
 }
 
 target "debian_jdk17" {
   dockerfile = "17/debian/Dockerfile"
   context = "."
   args = {
-    version = "${REMOTING_VERSION}-${AGENT_IMAGE_BUILD_NUMBER}-jdk17-preview"
+    version = "${REMOTING_VERSION}.${AGENT_IMAGE_BUILD_NUMBER}-jdk17-preview"
   }
   tags = [
     equal(ON_TAG, "true") ? "${REGISTRY}/${JENKINS_REPO}:${REMOTING_VERSION}-${BUILD_NUMBER}-jdk17-preview": "",
     "${REGISTRY}/${JENKINS_REPO}:jdk17-preview",
     "${REGISTRY}/${JENKINS_REPO}:latest-jdk17-preview",
   ]
-  platforms = ["linux/amd64", "linux/arm64"]
+  platforms = ["linux/amd64", "linux/arm64", "linux/arm/v7"]
 }


### PR DESCRIPTION
The `4.13.x` `docker-agent` latest [release](https://hub.docker.com/r/jenkins/agent/tags?page=1&name=4.13.2-1-jdk17) now handles `linux/arm/v7`, so I just changed the `AGENT_IMAGE_BUILD_NUMBER` to take that into account, the two references for `Debian` to the version (`.` instead of `-`), and added `linux/arm/v7` to `Debian` for `JDK` 11 and 17 in the `Docker` bake file.

<!-- Please describe your pull request here. -->

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

It does work with 

```bash
docker buildx bake -f docker-bake.hcl debian_jdk11
```

and
```bash
docker buildx bake -f docker-bake.hcl debian_jdk17
```

on my machine.

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
