### PR TITLE
Remove "-preview" from Java 17 images

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -26,7 +26,7 @@ group "linux-ppc64le" {
 
 # update this to use a newer build number of the jenkins/agent image
 variable "AGENT_IMAGE_BUILD_NUMBER" {
-  default = "1"
+  default = "2"
 }
 
 variable "REGISTRY" {
@@ -88,9 +88,9 @@ target "alpine_jdk17" {
     version = "${REMOTING_VERSION}-${AGENT_IMAGE_BUILD_NUMBER}-alpine-jdk17"
   }
   tags = [
-    equal(ON_TAG, "true") ? "${REGISTRY}/${JENKINS_REPO}:${REMOTING_VERSION}-${BUILD_NUMBER}-alpine-jdk17-preview": "",
-    "${REGISTRY}/${JENKINS_REPO}:alpine-jdk17-preview",
-    "${REGISTRY}/${JENKINS_REPO}:latest-alpine-jdk17-preview",
+    equal(ON_TAG, "true") ? "${REGISTRY}/${JENKINS_REPO}:${REMOTING_VERSION}-${BUILD_NUMBER}-alpine-jdk17": "",
+    "${REGISTRY}/${JENKINS_REPO}:alpine-jdk17",
+    "${REGISTRY}/${JENKINS_REPO}:latest-alpine-jdk17",
   ]
   platforms = ["linux/amd64"]
 }
@@ -129,12 +129,12 @@ target "debian_jdk17" {
   dockerfile = "17/debian/Dockerfile"
   context = "."
   args = {
-    version = "${REMOTING_VERSION}-${AGENT_IMAGE_BUILD_NUMBER}-jdk17-preview"
+    version = "${REMOTING_VERSION}-${AGENT_IMAGE_BUILD_NUMBER}-jdk17"
   }
   tags = [
-    equal(ON_TAG, "true") ? "${REGISTRY}/${JENKINS_REPO}:${REMOTING_VERSION}-${BUILD_NUMBER}-jdk17-preview": "",
-    "${REGISTRY}/${JENKINS_REPO}:jdk17-preview",
-    "${REGISTRY}/${JENKINS_REPO}:latest-jdk17-preview",
+    equal(ON_TAG, "true") ? "${REGISTRY}/${JENKINS_REPO}:${REMOTING_VERSION}-${BUILD_NUMBER}-jdk17": "",
+    "${REGISTRY}/${JENKINS_REPO}:jdk17",
+    "${REGISTRY}/${JENKINS_REPO}:latest-jdk17",
   ]
   platforms = ["linux/amd64", "linux/arm64", "linux/arm/v7"]
 }


### PR DESCRIPTION
Closes #272

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
Removed "-preview" references in relation to Java 17. I'm assuming (perhaps incorrectly) that when the [related PR](https://github.com/jenkinsci/docker-agent/pull/275) goes in the build number goes up so have made that change too
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
See the [related PR](https://github.com/jenkinsci/docker-agent/pull/275) for the upstream `docker-agent` image
- N/A Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
