### PR TITLE
fix: only deploy to DockerHub on tag-triggered builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,8 +32,6 @@ pipeline {
                                         parallelBuilds[image] = {
                                             // Allocate a node for each image to avoid filling disk
                                             node('docker-windows') {
-                                                // Cleanup the Docker Engine if the machine is reused (to avoid harddrive being filled)
-                                                powershell 'docker.exe system prune --volumes --force'
                                                 checkout scm
                                                 powershell '& ./make.ps1 -Build ' + image + ' test'
                                                 junit(allowEmptyResults: true, keepLongStdio: true, testResults: 'target/**/junit-results.xml')
@@ -72,7 +70,7 @@ pipeline {
                         JENKINS_REPO = "${infra.isTrusted() ? 'jenkins' : 'jenkins4eval'}/inbound-agent"
                     }
                     stages {
-                        stage('Prepare Docker BuildX Runner for multi-arch') {
+                        stage('Prepare Docker') {
                             steps {
                                 sh '''
                                 docker buildx create --use

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -22,19 +22,18 @@ group "linux-ppc64le" {
   targets = []
 }
 
+#### This is the current (e.g. jenkins/inbound-agent) version (including build number suffix)
 variable "IMAGE_TAG" {
   default = "3063.v26e24490f041-1"
 }
-
 variable "REMOTING_VERSION" {
   default = split("-", "${IMAGE_TAG}")[0]
 }
-
 variable "BUILD_NUMBER" {
   default = split("-", "${IMAGE_TAG}")[1]
 }
 
-# update this to use a newer build number of the parent jenkins/agent image
+#### This is for the "parent" image to use: remoting version is interpolated from IMAGE_TAG) but parent image also have a build number suffix
 variable "AGENT_IMAGE_BUILD_NUMBER" {
   default = "1"
 }

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -46,11 +46,6 @@ variable "JENKINS_REPO" {
   default = "jenkins/inbound-agent"
 }
 
-# Used in the tag pushed to the jenkins/inbound-agent image, no need to update this the pipeline will change it
-variable "BUILD_NUMBER" {
-  default = "1"
-}
-
 variable "ON_TAG" {
   default = "false"
 }

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -22,7 +22,19 @@ group "linux-ppc64le" {
   targets = []
 }
 
-# update this to use a newer build number of the jenkins/agent image
+variable "IMAGE_TAG" {
+  default = "3063.v26e24490f041-1"
+}
+
+variable "REMOTING_VERSION" {
+  default = split("-", "${IMAGE_TAG}")[0]
+}
+
+variable "BUILD_NUMBER" {
+  default = split("-", "${IMAGE_TAG}")[1]
+}
+
+# update this to use a newer build number of the parent jenkins/agent image
 variable "AGENT_IMAGE_BUILD_NUMBER" {
   default = "1"
 }
@@ -33,10 +45,6 @@ variable "REGISTRY" {
 
 variable "JENKINS_REPO" {
   default = "jenkins/inbound-agent"
-}
-
-variable "REMOTING_VERSION" {
-  default = "3063.v26e24490f041"
 }
 
 # Used in the tag pushed to the jenkins/inbound-agent image, no need to update this the pipeline will change it

--- a/tests/netcat-helper/Dockerfile-windows
+++ b/tests/netcat-helper/Dockerfile-windows
@@ -36,5 +36,3 @@ RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tl
     $proc = Start-Process "C:\nmap-install.exe" -PassThru -ArgumentList '/S' ; `
     $proc.WaitForExit() ; `
     Remove-Item -Path nmap-install.exe
-
-


### PR DESCRIPTION
Related to https://github.com/jenkinsci/docker-inbound-agent/issues/279.

Closes https://github.com/jenkins-infra/helpdesk/issues/2

This PR updates the `Jenkinsfile` (pipeline) and the `docker-bake.hcl` manifest with the following changes:

- fix(Jenkinsfile): only deploy to DockerHub (`--push` argument for `docker buildx bake` command) when a tag triggered a build
- fix(Jenkinsfile): stop polling for code change, to avoid triggering unexpected tag builds
- chore(Jenkins): use declarative syntax as much as posible (simplification)
- feat(docker-bake.hcl) automatic detection of the remoting version and build number from the tag
