### PR TITLE
chore(test) fix build argument tests by using an old version

### DIFF
--- a/tests/inboundAgent.Tests.ps1
+++ b/tests/inboundAgent.Tests.ps1
@@ -128,15 +128,16 @@ Describe "[$global:JDK $global:FLAVOR] image starts jenkins-agent.ps1 correctly 
 Describe "[$global:JDK $global:FLAVOR] build args" {
     BeforeAll {
         Push-Location -StackName 'agent' -Path "$PSScriptRoot/.."
-        # an old jdk11 image version
-        $TEST_VERSION="3063.v26e24490f041"
+        # Old version used to test overriding the build arguments.
+        # This old version must have the same tag suffixes as the current 4 windows images (`-jdk11-nanoserver` etc.)
+        $TEST_VERSION="3046.v38db_38a_b_7a_86"
         $DOCKER_AGENT_VERSION_SUFFIX="1"
         $TEST_USER="foo"
         $ARG_TEST_VERSION="${TEST_VERSION}-${DOCKER_AGENT_VERSION_SUFFIX}"
     }
 
     It 'builds image with arguments' {
-        $exitCode, $stdout, $stderr = Run-Program 'docker.exe' "build --build-arg VERSION=${ARG_TEST_VERSION} --build-arg user=$TEST_USER -t $global:AGENT_IMAGE $global:FOLDER"
+        $exitCode, $stdout, $stderr = Run-Program 'docker.exe' "build --build-arg version=${ARG_TEST_VERSION} --build-arg user=$TEST_USER -t $global:AGENT_IMAGE $global:FOLDER"
         $exitCode | Should -Be 0
 
         $exitCode, $stdout, $stderr = Run-Program 'docker.exe' "run -dit --name $global:AGENT_CONTAINER -P $global:AGENT_IMAGE -Cmd $global:SHELL"

--- a/tests/tests.bats
+++ b/tests/tests.bats
@@ -45,11 +45,14 @@ SUT_IMAGE=$(get_sut_image)
 @test "[${SUT_IMAGE}] use build args correctly" {
   cd "${BATS_TEST_DIRNAME}"/.. || false
 
-  local ARG_TEST_VERSION
-  local TEST_VERSION="3063.v26e24490f041"
+  # Old version used to test overriding the build arguments.
+  # This old version must have the same tag suffixes as the ones defined in the docker-bake file (`-jdk17`, `jdk11`, etc.)
+  local TEST_VERSION="3046.v38db_38a_b_7a_86"
   local DOCKER_AGENT_VERSION_SUFFIX="1"
-  local TEST_USER="root"
+
   local ARG_TEST_VERSION="${TEST_VERSION}-${DOCKER_AGENT_VERSION_SUFFIX}"
+  local TEST_USER="root"
+
 
   local FOLDER=$(get_dockerfile_directory)
 


### PR DESCRIPTION
This PR takes in account the review feedbacks in https://github.com/jenkinsci/docker-inbound-agent/pull/285#discussion_r983710604.

It aims at fixing the test harness, when testing the build argument overriding to target users who consume the `Dockerfile`.

It uses an "older" version that is compliant with the current list of tags (e.g. `-jdk17` but not `-jdk17-preview` for instance).