### PR TITLE
hotfix(windows) fix deploy error on the pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -44,6 +44,9 @@ pipeline {
                             }
                         }
                         stage('Deploy to DockerHub') {
+                            agent {
+                                label 'docker-windows'
+                            }
                             // This stage is the "CD" and should only be run when a tag triggered the build
                             when {
                                 buildingTag()


### PR DESCRIPTION
The deployment pipeline fails for the Windows "Deploy on DockerHub" stage with the following error:

```
Required context class hudson.Launcher is missing
Perhaps you forgot to surround the code with a step that provides this, such as: node
```


This PR fixes it