### PR TITLE
Drop ppc64le support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ export DOCKER_CLI_EXPERIMENTAL=enabled
 export BUILDKIT_PROGRESS=plain
 
 current_arch := $(shell uname -m)
-export ARCH ?= $(shell case $(current_arch) in (x86_64) echo "amd64" ;; (i386) echo "386";; (aarch64|arm64) echo "arm64" ;; (armv6*) echo "arm/v6";; (armv7*) echo "arm/v7";; (ppc64*|s390*|riscv*) echo $(current_arch);; (*) echo "UNKNOWN-CPU";; esac)
+export ARCH ?= $(shell case $(current_arch) in (x86_64) echo "amd64" ;; (i386) echo "386";; (aarch64|arm64) echo "arm64" ;; (armv6*) echo "arm/v6";; (armv7*) echo "arm/v7";; (s390*|riscv*) echo $(current_arch);; (*) echo "UNKNOWN-CPU";; esac)
 
 # Set to the path of a specific test suite to restrict execution only to this
 # default is "all test suites in the "tests/" directory

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -18,10 +18,6 @@ group "linux-s390x" {
   targets = []
 }
 
-group "linux-ppc64le" {
-  targets = []
-}
-
 #### This is the current (e.g. jenkins/inbound-agent) version (including build number suffix)
 variable "IMAGE_TAG" {
   default = "3063.v26e24490f041-1"


### PR DESCRIPTION
## Drop ppc64le support

IBM no longer provides the PowerPC agents that we use to test and verify PowerPC support. Can't support an architecture that we can't test.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
