### PR TITLE
Do not check Java 8 dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,28 +15,3 @@ updates:
   schedule:
     interval: weekly
   open-pull-requests-limit: 10
-- package-ecosystem: docker
-  directory: "/8/windows/nanoserver-1809"
-  schedule:
-    interval: weekly
-  open-pull-requests-limit: 10
-- package-ecosystem: docker
-  directory: "/8/windows/windowsservercore-1809"
-  schedule:
-    interval: weekly
-  open-pull-requests-limit: 10
-- package-ecosystem: docker
-  directory: "/8/windows/windowsservercore-ltsc2019"
-  schedule:
-    interval: weekly
-  open-pull-requests-limit: 10
-- package-ecosystem: docker
-  directory: "/8/debian"
-  schedule:
-    interval: weekly
-  open-pull-requests-limit: 10
-- package-ecosystem: docker
-  directory: "/8/alpine"
-  schedule:
-    interval: weekly
-  open-pull-requests-limit: 10


### PR DESCRIPTION
## Do not check Java 8 dependencies

No more Java 8 support in this branch

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
