### PR TITLE
chore(updatecli) add a manifest to track the parent image version 

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,17 +1,12 @@
+# Per https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates
 version: 2
 updates:
-- package-ecosystem: docker
-  directory: "/11/windows/windowsservercore-ltsc2019"
+
+# GitHub actions
+
+- package-ecosystem: "github-actions"
+  target-branch: master
+  directory: "/"
   schedule:
-    interval: weekly
-  open-pull-requests-limit: 10
-- package-ecosystem: docker
-  directory: "/11/windows/nanoserver-1809"
-  schedule:
-    interval: weekly
-  open-pull-requests-limit: 10
-- package-ecosystem: docker
-  directory: "/11/debian"
-  schedule:
-    interval: weekly
-  open-pull-requests-limit: 10
+    # Check for updates to GitHub Actions every week
+    interval: "weekly"

--- a/.github/workflows/updatecli.yaml
+++ b/.github/workflows/updatecli.yaml
@@ -1,0 +1,29 @@
+name: updatecli
+on:
+  # Allow to be run manually
+  workflow_dispatch:
+  schedule:
+    # Run once per week (to avoid alert fatigue)
+    - cron: '0 2 * * 1' # Every Monday at 2am UTC
+  push:
+  pull_request:
+jobs:
+  updatecli:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install Updatecli in the runner
+        uses: updatecli/updatecli-action@v2.13.0
+
+      - name: Run Updatecli in Dry Run mode
+        run: updatecli diff --config ./updatecli/updatecli.d --values ./updatecli/values.github-action.yaml
+        env:
+          UPDATECLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run Updatecli in Apply mode
+        if: github.ref == 'refs/heads/master'
+        run: updatecli apply --config ./updatecli/updatecli.d --values ./updatecli/values.github-action.yaml
+        env:
+          UPDATECLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/updatecli/updatecli.d/jenkins-agent-parent.yaml
+++ b/updatecli/updatecli.d/jenkins-agent-parent.yaml
@@ -204,6 +204,26 @@ targets:
         keyword: ARG
         matcher: version
     scmid: default
+  setDockerBakeDefaultParentImage:
+    name: Bump the parent image `jenkins/agent` version on the docker-bake.hcl file
+    kind: file
+    spec:
+      file: docker-bake.hcl
+      matchpattern: >-
+        variable(.*)"PARENT_IMAGE_VERSION"(.*){(.*)(\r\n|\r|\n)(.*)default(.*)=(.*)
+      replacepattern: >-
+        variable${1}"PARENT_IMAGE_VERSION"${2}{${3}${4}${5}default${6}= "{{ source "lastVersion" }}"
+    scmid: default
+  setWindowsMakePwshParentImage:
+    name: Bump the parent image `jenkins/agent` version on the windows make.ps1 file
+    kind: file
+    spec:
+      file: make.ps1
+      matchpattern: >-
+        \$DockerAgentVersion(.*)=(.*),
+      replacepattern: >-
+        $$DockerAgentVersion${1}= '{{ source "lastVersion" }}',
+    scmid: default
 
 pullrequests:
   default:

--- a/updatecli/updatecli.d/jenkins-agent-parent.yaml
+++ b/updatecli/updatecli.d/jenkins-agent-parent.yaml
@@ -1,0 +1,216 @@
+---
+name: Bump the parent image `jenkins/agent` version
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  lastVersion:
+    kind: githubrelease
+    name: Get the latest version of the parent image `jenkins/agent`
+    spec:
+      owner: jenkinsci
+      repository: docker-agent
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      versionfilter:
+        kind: latest
+
+conditions:
+  checkJdk11AlpineDockerImage:
+    kind: dockerimage
+    name: Check if the container image "jenkins/agent:<lastVersion>-alpine-jdk11" for linux/amd64 is available
+    disablesourceinput: true
+    spec:
+      architecture: amd64
+      image: jenkins/agent
+      tag: '{{source "lastVersion" }}-alpine-jdk11'
+  checkJdk17AlpineDockerImage:
+    kind: dockerimage
+    name: Check if the container image "jenkins/agent:<lastVersion>-alpine-jdk17" for linux/amd64 is available
+    disablesourceinput: true
+    spec:
+      architecture: amd64
+      image: jenkins/agent
+      tag: '{{source "lastVersion" }}-alpine-jdk17'
+  checkJdk11DebianAmd64DockerImage:
+    kind: dockerimage
+    name: Check if the container image "jenkins/agent:<lastVersion>-jdk11" for linux/amd64 is available
+    disablesourceinput: true
+    spec:
+      architecture: amd64
+      image: jenkins/agent
+      tag: '{{source "lastVersion" }}-jdk11'
+  checkJdk11DebianArm64DockerImage:
+    kind: dockerimage
+    name: Check if the container image "jenkins/agent:<lastVersion>-jdk11" for linux/arm64 is available
+    disablesourceinput: true
+    spec:
+      architecture: arm64
+      image: jenkins/agent
+      tag: '{{source "lastVersion" }}-jdk11'
+  checkJdk11DebianArmv7DockerImage:
+    kind: dockerimage
+    name: Check if the container image "jenkins/agent:<lastVersion>-jdk11" for linux/arm/v7 is available
+    disablesourceinput: true
+    spec:
+      architecture: arm/v7
+      image: jenkins/agent
+      tag: '{{source "lastVersion" }}-jdk11'
+  checkJdk11DebianS390xDockerImage:
+    kind: dockerimage
+    name: Check if the container image "jenkins/agent:<lastVersion>-jdk11" for linux/s390x is available
+    disablesourceinput: true
+    spec:
+      architecture: s390x
+      image: jenkins/agent
+      tag: '{{source "lastVersion" }}-jdk11'
+  checkJdk17DebianAmd64DockerImage:
+    kind: dockerimage
+    name: Check if the container image "jenkins/agent:<lastVersion>-jdk17" for linux/amd64 is available
+    disablesourceinput: true
+    spec:
+      architecture: amd64
+      image: jenkins/agent
+      tag: '{{source "lastVersion" }}-jdk17'
+  checkJdk17DebianArm64DockerImage:
+    kind: dockerimage
+    name: Check if the container image "jenkins/agent:<lastVersion>-jdk17" for linux/arm64 is available
+    disablesourceinput: true
+    spec:
+      architecture: arm64
+      image: jenkins/agent
+      tag: '{{source "lastVersion" }}-jdk17'
+  checkJdk17DebianArmv7DockerImage:
+    kind: dockerimage
+    name: Check if the container image "jenkins/agent:<lastVersion>-jdk17" for linux/arm/v7 is available
+    disablesourceinput: true
+    spec:
+      architecture: arm/v7
+      image: jenkins/agent
+      tag: '{{source "lastVersion" }}-jdk17'
+  checkJdk11WindowsNanoserver1809DockerImage:
+    kind: dockerimage
+    name: Check if the container image "jenkins/agent:<lastVersion>-jdk11-nanoserver-1809" for windows/amd64 is available
+    disablesourceinput: true
+    spec:
+      architecture: amd64
+      image: jenkins/agent
+      tag: '{{source "lastVersion" }}-jdk11-nanoserver-1809'
+  checkJdk17WindowsNanoserver1809DockerImage:
+    kind: dockerimage
+    name: Check if the container image "jenkins/agent:<lastVersion>-jdk17-nanoserver-1809" for windows/amd64 is available
+    disablesourceinput: true
+    spec:
+      architecture: amd64
+      image: jenkins/agent
+      tag: '{{source "lastVersion" }}-jdk17-nanoserver-1809'
+  checkJdk11WindowsServer2019DockerImage:
+    kind: dockerimage
+    name: Check if the container image "jenkins/agent:<lastVersion>-jdk11-windowsservercore-ltsc2019" for windows/amd64 is available
+    disablesourceinput: true
+    spec:
+      architecture: amd64
+      image: jenkins/agent
+      tag: '{{source "lastVersion" }}-jdk11-windowsservercore-ltsc2019'
+  checkJdk17WindowsServer2019DockerImage:
+    kind: dockerimage
+    name: Check if the container image "jenkins/agent:<lastVersion>-jdk17-windowsservercore-ltsc2019" for windows/amd64 is available
+    disablesourceinput: true
+    spec:
+      architecture: amd64
+      image: jenkins/agent
+      tag: '{{source "lastVersion" }}-jdk17-windowsservercore-ltsc2019'
+
+targets:
+  setJdk11AlpineDockerImage:
+    name: Bump the parent image `jenkins/agent` version on JDK11 Alpine
+    kind: dockerfile
+    spec:
+      file: 11/alpine/Dockerfile
+      instruction:
+        keyword: ARG
+        matcher: version
+    scmid: default
+  setJdk11DebianDockerImage:
+    name: Bump the parent image `jenkins/agent` version on JDK11 Debian
+    kind: dockerfile
+    spec:
+      file: 11/alpine/Dockerfile
+      instruction:
+        keyword: ARG
+        matcher: version
+    scmid: default
+  setJdk11WindowsNanoserver1809DockerImage:
+    name: Bump the parent image `jenkins/agent` version on JDK11 Windows Nanoserver 1809
+    kind: dockerfile
+    spec:
+      file: 11/windows/nanoserver-1809/Dockerfile
+      instruction:
+        keyword: ARG
+        matcher: version
+    scmid: default
+  setJdk11WindowsServer2019DockerImage:
+    name: Bump the parent image `jenkins/agent` version on JDK11 Windows Server 2019
+    kind: dockerfile
+    spec:
+      file: 11/windows/windowsservercore-ltsc2019/Dockerfile
+      instruction:
+        keyword: ARG
+        matcher: version
+    scmid: default
+  setJdk17AlpineDockerImage:
+    name: Bump the parent image `jenkins/agent` version on JDK17 Alpine
+    kind: dockerfile
+    spec:
+      file: 17/alpine/Dockerfile
+      instruction:
+        keyword: ARG
+        matcher: version
+    scmid: default
+  setJdk17DebianDockerImage:
+    name: Bump the parent image `jenkins/agent` version on JDK17 Debian
+    kind: dockerfile
+    spec:
+      file: 17/alpine/Dockerfile
+      instruction:
+        keyword: ARG
+        matcher: version
+    scmid: default
+  setJdk17WindowsNanoserver1809DockerImage:
+    name: Bump the parent image `jenkins/agent` version on JDK17 Windows Nanoserver 1809
+    kind: dockerfile
+    spec:
+      file: 17/windows/nanoserver-1809/Dockerfile
+      instruction:
+        keyword: ARG
+        matcher: version
+    scmid: default
+  setJdk17WindowsServer2019DockerImage:
+    name: Bump the parent image `jenkins/agent` version on JDK17 Windows Server 2019
+    kind: dockerfile
+    spec:
+      file: 17/windows/windowsservercore-ltsc2019/Dockerfile
+      instruction:
+        keyword: ARG
+        matcher: version
+    scmid: default
+
+pullrequests:
+  default:
+    kind: github
+    scmid: default
+    title: Bump the parent image `jenkins/agent` version to {{ source "lastVersion" }}
+    spec:
+      labels:
+        - dependencies
+        - jenkins/agent

--- a/updatecli/values.github-action.yaml
+++ b/updatecli/values.github-action.yaml
@@ -1,0 +1,8 @@
+github:
+  user: "GitHub Actions"
+  email: "41898282+github-actions[bot]@users.noreply.github.com"
+  username: "github-actions"
+  token: "UPDATECLI_GITHUB_TOKEN"
+  branch: "master"
+  owner: "jenkinsci"
+  repository: "docker-inbound-agent"


### PR DESCRIPTION
This PR enable updatecli tracking of the parent image version (`jenkins/agent`).

Once merged, we expect an automatic PR to bump the parent version to `3071.v7e9b_0dc08466-2`.

Please note that dependenabot configuration is updated as part of this PR to:

- Stop tracking Docker parent image (since we use the `ARG` version)
- Keep the GitHub actions up to date (because updatecli and release drafter)

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- ~[ ] Link to relevant issues in GitHub or Jira~
- ~[ ] Link to relevant pull requests, esp. upstream and downstream changes~
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
