### PR TITLE
chore(linux tests) apply shellcheck and fix concurency issues

### DIFF
--- a/tests/test_helpers.bash
+++ b/tests/test_helpers.bash
@@ -8,7 +8,7 @@ set -eu
 )>&2
 
 function printMessage {
-  echo "# ${@}" >&3
+    echo "# ${*}" >&3
 }
 
 # Assert that $1 is the output of a command $2
@@ -56,28 +56,21 @@ function get_sut_image {
     make --silent show | jq -r ".target.${IMAGE}.tags[0]"
 }
 
-function get_dockerfile_directory() {
-    test -n "${IMAGE:?"[sut_image] Please set the variable 'IMAGE' to the name of the image to test in 'docker-bake.hcl'."}"
-
-    DOCKERFILE=$(make --silent show | jq -r ".target.${IMAGE}.dockerfile")
-    echo "${DOCKERFILE%"/Dockerfile"}"
-}
-
 function clean_test_container {
 	docker kill "${AGENT_CONTAINER}" "${NETCAT_HELPER_CONTAINER}" &>/dev/null || :
 	docker rm -fv "${AGENT_CONTAINER}" "${NETCAT_HELPER_CONTAINER}" &>/dev/null || :
 }
 
 function is_agent_container_running {
-  local cid="${1}"
+    local cid="${1}"
 	sleep 1
 	retry 3 1 assert "true" docker inspect -f '{{.State.Running}}' "${cid}"
 }
 
 function buildNetcatImage() {
-  if ! docker inspect --type=image netcat-helper:latest &>/dev/null; then
-    docker build -t netcat-helper:latest tests/netcat-helper/ &>/dev/null
-  fi
+    if ! docker inspect --type=image netcat-helper:latest &>/dev/null; then
+        docker build -t netcat-helper:latest tests/netcat-helper/ &>/dev/null
+    fi
 }
 
 function cleanup {

--- a/tests/tests.bats
+++ b/tests/tests.bats
@@ -32,13 +32,11 @@ SUT_IMAGE="$(get_sut_image)"
   sut_cid="$(docker run -d --link "${netcat_cid}" "${SUT_IMAGE}" -url "http://${netcat_cid}:5000" aaa bbb)"
 
   # Wait for the whole process to take place (in resource-constrained environments it can take 100s of milliseconds)
-  sleep 1
+  sleep 5
 
-  # Capture the logs output from netcat and compare the first line
-  # of the header of the first HTTP request with the expected one
+  # Capture the logs output from netcat and check the header of the first HTTP request with the expected one
   run docker logs "${netcat_cid}"
-
-  [[ "${lines[0]}" = *"GET /tcpSlaveAgentListener/ HTTP/1.1"* ]]
+  echo "${output}" | grep 'GET /tcpSlaveAgentListener/ HTTP/1.1'
 
   cleanup "${netcat_cid}"
   cleanup "${sut_cid}"

--- a/tests/tests.bats
+++ b/tests/tests.bats
@@ -1,80 +1,81 @@
 #!/usr/bin/env bats
 
 AGENT_CONTAINER=bats-jenkins-jnlp-agent
-NETCAT_HELPER_CONTAINER=netcat-helper
 
 load test_helpers
 
 buildNetcatImage
 
-SUT_IMAGE=$(get_sut_image)
+SUT_IMAGE="$(get_sut_image)"
 
 @test "[${SUT_IMAGE}] image has installed jenkins-agent in PATH" {
-  cid=$(docker run -d -it -P "${SUT_IMAGE}" /bin/bash)
+  local sut_cid
+  sut_cid="$(docker run -d -it -P "${SUT_IMAGE}" /bin/bash)"
 
-  is_agent_container_running $cid
+  is_agent_container_running "${sut_cid}"
 
-  run docker exec "${cid}" which jenkins-agent
+  run docker exec "${sut_cid}" which jenkins-agent
   [ "/usr/local/bin/jenkins-agent" = "${lines[0]}" ]
 
-  run docker exec "${cid}" which jenkins-agent
+  run docker exec "${sut_cid}" which jenkins-agent
   [ "/usr/local/bin/jenkins-agent" = "${lines[0]}" ]
 
-  cleanup $cid
+  cleanup "${sut_cid}"
 }
 
 @test "[${SUT_IMAGE}] image starts jenkins-agent correctly (slow test)" {
-  #  Spin off a helper image which contains netcat
-  netcat_cid=$(docker run -d -it --name netcat-helper netcat-helper:latest /bin/sh)
+  local netcat_cid sut_cid
+  # Spin off a helper image which launches the netcat utility, listening at port 5000 for 30 sec
+  netcat_cid="$(docker run -d -it netcat-helper:latest /bin/sh -c "timeout 30s nc -l 5000")"
 
   # Run jenkins agent which tries to connect to the netcat-helper container at port 5000
-  cid=$(docker run -d --link netcat-helper "${SUT_IMAGE}" -url http://netcat-helper:5000 aaa bbb)
+  sut_cid="$(docker run -d --link "${netcat_cid}" "${SUT_IMAGE}" -url "http://${netcat_cid}:5000" aaa bbb)"
 
-  # Launch the netcat utility, listening at port 5000 for 30 sec
-  # bats will capture the output from netcat and compare the first line
+  # Wait for the whole process to take place (in resource-constrained environments it can take 100s of milliseconds)
+  sleep 1
+
+  # Capture the logs output from netcat and compare the first line
   # of the header of the first HTTP request with the expected one
-  run docker exec netcat-helper /bin/sh -c "timeout 30s nc -l 5000"
+  run docker logs "${netcat_cid}"
 
-  # The GET request ends with a '\r'
-  [ $'GET /tcpSlaveAgentListener/ HTTP/1.1\r' = "${lines[0]}" ]
+  [[ "${lines[0]}" = *"GET /tcpSlaveAgentListener/ HTTP/1.1"* ]]
 
-  cleanup $netcat_cid
-  cleanup $cid
+  cleanup "${netcat_cid}"
+  cleanup "${sut_cid}"
 }
 
 @test "[${SUT_IMAGE}] use build args correctly" {
   cd "${BATS_TEST_DIRNAME}"/.. || false
 
+  local TEST_VERSION DOCKER_AGENT_VERSION_SUFFIX ARG_TEST_VERSION TEST_USER sut_image sut_cid
+
   # Old version used to test overriding the build arguments.
   # This old version must have the same tag suffixes as the ones defined in the docker-bake file (`-jdk17`, `jdk11`, etc.)
-  local TEST_VERSION="3046.v38db_38a_b_7a_86"
-  local DOCKER_AGENT_VERSION_SUFFIX="1"
+  TEST_VERSION="3046.v38db_38a_b_7a_86"
+  DOCKER_AGENT_VERSION_SUFFIX="1"
 
-  local ARG_TEST_VERSION="${TEST_VERSION}-${DOCKER_AGENT_VERSION_SUFFIX}"
-  local TEST_USER="root"
+  ARG_TEST_VERSION="${TEST_VERSION}-${DOCKER_AGENT_VERSION_SUFFIX}"
+  TEST_USER="root"
 
-
-  local FOLDER=$(get_dockerfile_directory)
-
-  local sut_image="${SUT_IMAGE}-tests-${BATS_TEST_NUMBER}"
+  sut_image="${SUT_IMAGE}-tests-${BATS_TEST_NUMBER}"
 
   docker buildx bake \
     --set "${IMAGE}".args.version="${ARG_TEST_VERSION}" \
     --set "${IMAGE}".args.user="${TEST_USER}" \
-    --set "${IMAGE}".platform="linux/${ARCH}" \
+    --set "${IMAGE}".platform=linux/"${ARCH}" \
     --set "${IMAGE}".tags="${sut_image}" \
     --load \
       "${IMAGE}"
 
-  cid=$(docker run -d -it --name "${AGENT_CONTAINER}" -P "${sut_image}" /bin/sh)
+  sut_cid="$(docker run -d -it --name "${AGENT_CONTAINER}" -P "${sut_image}" /bin/sh)"
 
-  is_agent_container_running $cid
+  is_agent_container_running "${sut_cid}"
 
-  run docker exec "${cid}" sh -c "java -cp /usr/share/jenkins/agent.jar hudson.remoting.jnlp.Main -version"
+  run docker exec "${sut_cid}" sh -c "java -cp /usr/share/jenkins/agent.jar hudson.remoting.jnlp.Main -version"
   [ "${TEST_VERSION}" = "${lines[0]}" ]
 
   run docker exec "${AGENT_CONTAINER}" sh -c "id -u -n ${TEST_USER}"
   [ "${TEST_USER}" = "${lines[0]}" ]
 
-  cleanup $cid
+  cleanup "${sut_cid}"
 }


### PR DESCRIPTION
While debugging https://github.com/jenkinsci/docker-inbound-agent/pull/296 (why are the Linux tests failing for JDK17 Debian only? Why not reproducible locally?) I realized that the bats test was not ready for concurent executions (which is the case in the CI).

This PR aims at fixing this by:

- Applying shellcheck rules on the test harness
- Using `local` shell keyword to mark variables local to function and avoid scope issues
- Fix the order of the "netcat/SUT" container flow + add 1s sleep to let time to the system to start the inbound process

----

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
