### PR TITLE
feat: add archlinux JDK11 image

### DIFF
--- a/11/archlinux/Dockerfile
+++ b/11/archlinux/Dockerfile
@@ -1,0 +1,34 @@
+# The MIT License
+#
+#  Copyright (c) 2022, Jenkins project and other Jenkins contributors
+#
+#  Permission is hereby granted, free of charge, to any person obtaining a copy
+#  of this software and associated documentation files (the "Software"), to deal
+#  in the Software without restriction, including without limitation the rights
+#  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+#  copies of the Software, and to permit persons to whom the Software is
+#  furnished to do so, subject to the following conditions:
+#
+#  The above copyright notice and this permission notice shall be included in
+#  all copies or substantial portions of the Software.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+#  THE SOFTWARE.
+
+ARG version=3071.v7e9b_0dc08466-1
+FROM jenkins/agent:${version}-archlinux-jdk11
+
+ARG user=jenkins
+
+USER root
+COPY ../../jenkins-agent /usr/local/bin/jenkins-agent
+RUN chmod +x /usr/local/bin/jenkins-agent &&\
+    ln -s /usr/local/bin/jenkins-agent /usr/local/bin/jenkins-slave
+USER ${user}
+
+ENTRYPOINT ["/usr/local/bin/jenkins-agent"]

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -4,6 +4,7 @@ group "linux" {
     "alpine_jdk17",
     "debian_jdk11",
     "debian_jdk17",
+    "archlinux_jdk11",
   ]
 }
 
@@ -99,4 +100,21 @@ target "debian_jdk17" {
     "${REGISTRY}/${JENKINS_REPO}:latest-jdk17",
   ]
   platforms = ["linux/amd64", "linux/arm64", "linux/arm/v7"]
+}
+
+target "archlinux_jdk11" {
+  dockerfile = "11/archlinux/Dockerfile"
+  context = "."
+  args = {
+    version = "${PARENT_IMAGE_VERSION}"
+  }
+  tags = [
+    equal(ON_TAG, "true") ? "${REGISTRY}/${JENKINS_REPO}:${PARENT_IMAGE_VERSION}-archlinux": "",
+    equal(ON_TAG, "true") ? "${REGISTRY}/${JENKINS_REPO}:${PARENT_IMAGE_VERSION}-archlinux-jdk11" : "",
+    "${REGISTRY}/${JENKINS_REPO}:archlinux",
+    "${REGISTRY}/${JENKINS_REPO}:latest-archlinux",
+    "${REGISTRY}/${JENKINS_REPO}:archlinux-jdk11",
+    "${REGISTRY}/${JENKINS_REPO}:latest-archlinux-jdk11",
+  ]
+  platforms = ["linux/amd64"]
 }

--- a/updatecli/updatecli.d/jenkins-agent-parent.yaml
+++ b/updatecli/updatecli.d/jenkins-agent-parent.yaml
@@ -42,6 +42,14 @@ conditions:
       architecture: amd64
       image: jenkins/agent
       tag: '{{source "lastVersion" }}-alpine-jdk17'
+  checkJdk11ArchlinuxDockerImage:
+    kind: dockerimage
+    name: Check if the container image "jenkins/agent:<lastVersion>-archlinux-jdk11" for linux/amd64 is available
+    disablesourceinput: true
+    spec:
+      architecture: amd64
+      image: jenkins/agent
+      tag: '{{source "lastVersion" }}-archlinux-jdk11'
   checkJdk11DebianAmd64DockerImage:
     kind: dockerimage
     name: Check if the container image "jenkins/agent:<lastVersion>-jdk11" for linux/amd64 is available
@@ -137,6 +145,15 @@ targets:
     kind: dockerfile
     spec:
       file: 11/alpine/Dockerfile
+      instruction:
+        keyword: ARG
+        matcher: version
+    scmid: default
+  setJdk11AarchlinuxDockerImage:
+    name: Bump the parent image `jenkins/agent` version on JDK11 Archlinux
+    kind: dockerfile
+    spec:
+      file: 11/archlinux/Dockerfile
       instruction:
         keyword: ARG
         matcher: version


### PR DESCRIPTION
https://github.com/jenkinsci/docker-agent/pull/171 was merged more than 1.5 year ago but never delivered.

This PR adds the Archlinux image for inbound agent.

Why a new base OS? Because it make sense, contrary to the controller image, to support more OSes to help end user to customize easily their agent with their own tools and encourage building an agents rather than on controllers.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue



PS: please note that updatecli fails because it tries to run on the principal branch rather than the branch itself.
