### PR TITLE
fix: keep the parent image label with the proper remoting version (fixes hadolint violations)

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -24,9 +24,6 @@ ARG version=3148.v532a_7e715ee3-1
 ARG JAVA_MAJOR_VERSION=17
 FROM jenkins/agent:"${version}"-alpine-jdk"${JAVA_MAJOR_VERSION}"
 
-ARG version=3148.v532a_7e715ee3-1
-LABEL Description="This is a base image, which allows connecting Jenkins agents via JNLP protocols" Vendor="Jenkins project" Version="$version"
-
 ARG user=jenkins
 
 USER root

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -2,9 +2,6 @@ ARG version=3148.v532a_7e715ee3-1
 ARG JAVA_MAJOR_VERSION=17
 FROM jenkins/agent:"${version}"-jdk"${JAVA_MAJOR_VERSION}"
 
-ARG version=3148.v532a_7e715ee3-1
-LABEL Description="This is a base image, which allows connecting Jenkins agents via JNLP protocols" Vendor="Jenkins project" Version="$version"
-
 ARG user=jenkins
 
 USER root

--- a/windows/nanoserver/Dockerfile
+++ b/windows/nanoserver/Dockerfile
@@ -26,8 +26,5 @@ ARG JAVA_MAJOR_VERSION=17
 ARG WINDOWS_VERSION_TAG=1809
 FROM jenkins/agent:"${version}"-jdk"${JAVA_MAJOR_VERSION}"-nanoserver-"${WINDOWS_VERSION_TAG}"
 
-ARG version=3148.v532a_7e715ee3-1
-LABEL Description="This is a base image, which allows connecting Jenkins agents via JNLP protocols on Windows" Vendor="Jenkins Project" Version="$version"
-
 COPY jenkins-agent.ps1 C:/ProgramData/Jenkins
 ENTRYPOINT ["pwsh.exe", "-f", "C:/ProgramData/Jenkins/jenkins-agent.ps1"]

--- a/windows/windowsservercore/Dockerfile
+++ b/windows/windowsservercore/Dockerfile
@@ -26,8 +26,5 @@ ARG JAVA_MAJOR_VERSION=17
 ARG WINDOWS_VERSION_TAG=ltsc2019
 FROM jenkins/agent:"${version}"-jdk"${JAVA_MAJOR_VERSION}"-windowsservercore-"${WINDOWS_VERSION_TAG}"
 
-ARG version=3148.v532a_7e715ee3-1
-LABEL Description="This is a base image, which allows connecting Jenkins agents via JNLP protocols on Windows" Vendor="Jenkins Project" Version="$version"
-
 COPY jenkins-agent.ps1 C:/ProgramData/Jenkins
 ENTRYPOINT ["powershell.exe", "-f", "C:/ProgramData/Jenkins/jenkins-agent.ps1"]


### PR DESCRIPTION
Self-describing title :)

1 commit per rule.

- LABEL is removed (along with associated arguments) because it was not the same value between images, and it was overriding the parent's image, causing confusion. Now the "version" mentioned in the labels is the remoting version.
