### PR TITLE
chore(updatecli) fix deprecated syntax for 0.47.x line

### DIFF
--- a/updatecli/updatecli.d/jenkins-agent-parent.yaml
+++ b/updatecli/updatecli.d/jenkins-agent-parent.yaml
@@ -192,9 +192,9 @@ targets:
         $$DockerAgentVersion${1}= '{{ source "lastVersion" }}',
     scmid: default
 
-pullrequests:
+actions:
   default:
-    kind: github
+    kind: github/pullrequest
     scmid: default
     title: Bump the parent image `jenkins/agent` version to {{ source "lastVersion" }}
     spec:


### PR DESCRIPTION
This PR removes the updatecli warning about deprecated features.

Caught while reviewing #337 