### PR TITLE
Adding ppc64le builds for docker-inbound-agent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ export DOCKER_CLI_EXPERIMENTAL=enabled
 export BUILDKIT_PROGRESS=plain
 
 current_arch := $(shell uname -m)
-export ARCH ?= $(shell case $(current_arch) in (x86_64) echo "amd64" ;; (i386) echo "386";; (aarch64|arm64) echo "arm64" ;; (armv6*) echo "arm/v6";; (armv7*) echo "arm/v7";; (s390*|riscv*) echo $(current_arch);; (*) echo "UNKNOWN-CPU";; esac)
+export ARCH ?= $(shell case $(current_arch) in (x86_64) echo "amd64" ;; (i386) echo "386";; (aarch64|arm64) echo "arm64" ;; (armv6*) echo "arm/v6";; (armv7*) echo "arm/v7";; (s390*|riscv*|ppc64le) echo $(current_arch);; (*) echo "UNKNOWN-CPU";; esac)
 
 # Set to the path of a specific test suite to restrict execution only to this
 # default is "all test suites in the "tests/" directory

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -18,6 +18,13 @@ group "linux-s390x" {
   targets = []
 }
 
+group "linux-ppc64le" {
+  targets = [
+    "debian_jdk11",
+    "debian_jdk17",
+  ]
+}
+
 #### This is the current (e.g. jenkins/inbound-agent) version (including build number suffix). Overridden by release builds from GIT_TAG.
 variable "IMAGE_TAG" {
   default = "3071.v7e9b_0dc08466-1"
@@ -84,7 +91,7 @@ target "debian_jdk11" {
     "${REGISTRY}/${JENKINS_REPO}:latest",
     "${REGISTRY}/${JENKINS_REPO}:latest-jdk11",
   ]
-  platforms = ["linux/amd64", "linux/arm64", "linux/arm/v7", "linux/s390x"]
+  platforms = ["linux/amd64", "linux/arm64", "linux/arm/v7", "linux/s390x", "linux/ppc64le"]
 }
 
 target "debian_jdk17" {
@@ -98,5 +105,5 @@ target "debian_jdk17" {
     "${REGISTRY}/${JENKINS_REPO}:jdk17",
     "${REGISTRY}/${JENKINS_REPO}:latest-jdk17",
   ]
-  platforms = ["linux/amd64", "linux/arm64", "linux/arm/v7"]
+  platforms = ["linux/amd64", "linux/arm64", "linux/arm/v7", "linux/ppc64le"]
 }

--- a/updatecli/updatecli.d/jenkins-agent-parent.yaml
+++ b/updatecli/updatecli.d/jenkins-agent-parent.yaml
@@ -52,6 +52,7 @@ conditions:
         - arm64
         - arm/v7
         - s390x
+        - ppc64le
       image: jenkins/agent
       tag: '{{source "lastVersion" }}-jdk11'
   checkJdk17DebianDockerImages:


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
ppc64le builds for the debian_jdk11 and debian_jdk17 docker-inbound-agent images using buildx

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
