### PR TITLE
cleanup(windows) remove custom user (feature parity with Linux and delegating to parent image)

### DIFF
--- a/11/windows/nanoserver-1809/Dockerfile
+++ b/11/windows/nanoserver-1809/Dockerfile
@@ -27,15 +27,5 @@ FROM jenkins/agent:${version}-jdk11-nanoserver-1809
 ARG version=3107.v665000b_51092-5
 LABEL Description="This is a base image, which allows connecting Jenkins agents via JNLP protocols on Windows" Vendor="Jenkins Project" Version="$version"
 
-ARG user=jenkins
-
-RUN $output = net users ; `
-    if(-not ($output -match $env:user)) { `
-        net accounts /maxpwage:unlimited ; `
-        net user $env:user /add /expire:never /passwordreq:no ; `
-        net localgroup Administrators /add $env:user `
-    }
-
 COPY jenkins-agent.ps1 C:/ProgramData/Jenkins
-USER ${user}
-ENTRYPOINT ["pwsh.exe", "-f", "C:/ProgramData/Jenkins/jenkins-agent.ps1"]
+ENTRYPOINT ["powershell.exe", "-f", "C:/ProgramData/Jenkins/jenkins-agent.ps1"]

--- a/11/windows/nanoserver-1809/Dockerfile
+++ b/11/windows/nanoserver-1809/Dockerfile
@@ -28,4 +28,4 @@ ARG version=3107.v665000b_51092-5
 LABEL Description="This is a base image, which allows connecting Jenkins agents via JNLP protocols on Windows" Vendor="Jenkins Project" Version="$version"
 
 COPY jenkins-agent.ps1 C:/ProgramData/Jenkins
-ENTRYPOINT ["powershell.exe", "-f", "C:/ProgramData/Jenkins/jenkins-agent.ps1"]
+ENTRYPOINT ["pwsh.exe", "-f", "C:/ProgramData/Jenkins/jenkins-agent.ps1"]

--- a/11/windows/windowsservercore-ltsc2019/Dockerfile
+++ b/11/windows/windowsservercore-ltsc2019/Dockerfile
@@ -24,18 +24,8 @@
 ARG version=3107.v665000b_51092-5
 FROM jenkins/agent:${version}-jdk11-windowsservercore-ltsc2019
 
+ARG version=3107.v665000b_51092-5
 LABEL Description="This is a base image, which allows connecting Jenkins agents via JNLP protocols on Windows" Vendor="Jenkins Project" Version="$version"
 
-ARG user=jenkins
-
-RUN $output = net users ; `
-    if(-not ($output -match $env:user)) { `
-        net accounts /maxpwage:unlimited ; `
-        net user "$env:user" /add /expire:never /passwordreq:no ; `
-        net localgroup Administrators /add $env:user ; `
-        Set-LocalUser -Name $env:user -PasswordNeverExpires 1 `
-    }
-
 COPY jenkins-agent.ps1 C:/ProgramData/Jenkins
-USER ${user}
 ENTRYPOINT ["powershell.exe", "-f", "C:/ProgramData/Jenkins/jenkins-agent.ps1"]

--- a/17/windows/nanoserver-1809/Dockerfile
+++ b/17/windows/nanoserver-1809/Dockerfile
@@ -27,15 +27,5 @@ FROM jenkins/agent:${version}-jdk17-nanoserver-1809
 ARG version=3107.v665000b_51092-5
 LABEL Description="This is a base image, which allows connecting Jenkins agents via JNLP protocols on Windows" Vendor="Jenkins Project" Version="$version"
 
-ARG user=jenkins
-
-RUN $output = net users ; `
-    if(-not ($output -match $env:user)) { `
-        net accounts /maxpwage:unlimited ; `
-        net user $env:user /add /expire:never /passwordreq:no ; `
-        net localgroup Administrators /add $env:user `
-    }
-
 COPY jenkins-agent.ps1 C:/ProgramData/Jenkins
-USER ${user}
-ENTRYPOINT ["pwsh.exe", "-f", "C:/ProgramData/Jenkins/jenkins-agent.ps1"]
+ENTRYPOINT ["powershell.exe", "-f", "C:/ProgramData/Jenkins/jenkins-agent.ps1"]

--- a/17/windows/nanoserver-1809/Dockerfile
+++ b/17/windows/nanoserver-1809/Dockerfile
@@ -28,4 +28,4 @@ ARG version=3107.v665000b_51092-5
 LABEL Description="This is a base image, which allows connecting Jenkins agents via JNLP protocols on Windows" Vendor="Jenkins Project" Version="$version"
 
 COPY jenkins-agent.ps1 C:/ProgramData/Jenkins
-ENTRYPOINT ["powershell.exe", "-f", "C:/ProgramData/Jenkins/jenkins-agent.ps1"]
+ENTRYPOINT ["pwsh.exe", "-f", "C:/ProgramData/Jenkins/jenkins-agent.ps1"]

--- a/17/windows/windowsservercore-ltsc2019/Dockerfile
+++ b/17/windows/windowsservercore-ltsc2019/Dockerfile
@@ -24,18 +24,8 @@
 ARG version=3107.v665000b_51092-5
 FROM jenkins/agent:${version}-jdk17-windowsservercore-ltsc2019
 
+ARG version=3107.v665000b_51092-5
 LABEL Description="This is a base image, which allows connecting Jenkins agents via JNLP protocols on Windows" Vendor="Jenkins Project" Version="$version"
 
-ARG user=jenkins
-
-RUN $output = net users ; `
-    if(-not ($output -match $env:user)) { `
-        net accounts /maxpwage:unlimited ; `
-        net user "$env:user" /add /expire:never /passwordreq:no ; `
-        net localgroup Administrators /add $env:user ; `
-        Set-LocalUser -Name $env:user -PasswordNeverExpires 1 `
-    }
-
 COPY jenkins-agent.ps1 C:/ProgramData/Jenkins
-USER ${user}
 ENTRYPOINT ["powershell.exe", "-f", "C:/ProgramData/Jenkins/jenkins-agent.ps1"]

--- a/tests/inboundAgent.Tests.ps1
+++ b/tests/inboundAgent.Tests.ps1
@@ -38,16 +38,16 @@ BuildNcatImage
 
 Describe "[$global:JDK $global:FLAVOR] build image" {
     BeforeAll {
-      Push-Location -StackName 'agent' -Path "$PSScriptRoot/.."
+        Push-Location -StackName 'agent' -Path "$PSScriptRoot/.."
     }
 
     It 'builds image' {
-      $exitCode, $stdout, $stderr = Run-Program 'docker.exe' "build --build-arg VERSION=$global:VERSION -t $global:AGENT_IMAGE $global:FOLDER"
-      $exitCode | Should -Be 0
+        $exitCode, $stdout, $stderr = Run-Program 'docker.exe' "build --build-arg VERSION=$global:VERSION -t $global:AGENT_IMAGE $global:FOLDER"
+        $exitCode | Should -Be 0
     }
 
     AfterAll {
-      Pop-Location -StackName 'agent'
+        Pop-Location -StackName 'agent'
     }
 }
 
@@ -131,12 +131,11 @@ Describe "[$global:JDK $global:FLAVOR] build args" {
         # This old version must have the same tag suffixes as the current 4 windows images (`-jdk11-nanoserver` etc.)
         $TEST_VERSION="3046.v38db_38a_b_7a_86"
         $DOCKER_AGENT_VERSION_SUFFIX="1"
-        $TEST_USER="foo"
         $ARG_TEST_VERSION="${TEST_VERSION}-${DOCKER_AGENT_VERSION_SUFFIX}"
     }
 
     It 'builds image with arguments' {
-        $exitCode, $stdout, $stderr = Run-Program 'docker.exe' "build --build-arg version=${ARG_TEST_VERSION} --build-arg user=$TEST_USER -t $global:AGENT_IMAGE $global:FOLDER"
+        $exitCode, $stdout, $stderr = Run-Program 'docker.exe' "build --build-arg version=${ARG_TEST_VERSION} -t $global:AGENT_IMAGE $global:FOLDER"
         $exitCode | Should -Be 0
 
         $exitCode, $stdout, $stderr = Run-Program 'docker.exe' "run -dit --name $global:AGENT_CONTAINER -P $global:AGENT_IMAGE -Cmd $global:SHELL"
@@ -148,22 +147,6 @@ Describe "[$global:JDK $global:FLAVOR] build args" {
         $exitCode, $stdout, $stderr = Run-Program 'docker.exe' "exec $global:AGENT_CONTAINER $global:SHELL -c `"java -cp C:/ProgramData/Jenkins/agent.jar hudson.remoting.jnlp.Main -version`""
         $exitCode | Should -Be 0
         $stdout | Should -Match $TEST_VERSION
-    }
-
-    It "has the correct (overridden) user account and the container is running as that user" {
-        # check that the user exists and is the user the container is running as
-        $exitCode, $stdout, $stderr = Run-Program 'docker.exe' "exec $global:AGENT_CONTAINER $global:SHELL -c `"(Get-ChildItem env:\ | Where-Object { `$_.Name -eq 'USERNAME' }).Value`""
-        $exitCode | Should -Be 0
-        $stdout | Should -Match $TEST_USER
-    }
-
-    It "has the correct password policy for overridden user account" {
-        # check that $TEST_USER's password never expires and that password is NOT required to login
-        $exitCode, $stdout, $stderr = Run-Program 'docker.exe' "exec $global:AGENT_CONTAINER $global:SHELL -C `"if((net user $TEST_USER | Select-String -Pattern 'Password expires') -match 'Never') { exit 0 } else { net user $TEST_USER ; exit -1 }`""
-        $exitCode | Should -Be 0
-
-        $exitCode, $stdout, $stderr = Run-Program 'docker.exe' "exec $global:AGENT_CONTAINER $global:SHELL -C `"if((net user $TEST_USER | Select-String -Pattern 'Password required') -match 'No') { exit 0 } else { net user $TEST_USER ; exit -1 }`""
-        $exitCode | Should -Be 0
     }
 
     AfterAll {


### PR DESCRIPTION
This pull request is motivated by the failures in #340 on Windows Server Core images which are not able to execute the `net users` instruction on Windows Server 2019/2022.

It removes the customization of the "default user" under the following assumptions:

- It's the responsibility of the parent image to define the user
- Same feature parity as Linux images
- Future "merge inbound-agent with agent images" works would simplify this problem


=> the goal is to unblock #340 and ensure we can, again, deliver new version of the inbound-agent.

If you land on this PR and you are building this image with a custom user on a Windows image, different than the default `jenkins`, please open an issue explaining why do you need to do this to let us evaluate a solution.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

----

Boyscout changes:
- There was an issue with the `ARG version` in the `11/windows/windowsservercore-ltsc2019/Dockerfile` and `17/windows/windowsservercore-ltsc2019/Dockerfile` files (ref. https://docs.docker.com/engine/reference/builder/#scope) fixed in this PR
- A minor indentation issue fixed in the test harness for windows