### PR TITLE
chore(windows tests) improve harness (`docker` flags and commands)

### DIFF
--- a/tests/inboundAgent.Tests.ps1
+++ b/tests/inboundAgent.Tests.ps1
@@ -5,7 +5,6 @@ $global:AGENT_CONTAINER='pester-jenkins-inbound-agent'
 $global:SHELL="powershell.exe"
 
 $global:FOLDER = Get-EnvOrDefault 'FOLDER' ''
-$global:VERSION = Get-EnvOrDefault 'VERSION' '4.9-1'
 
 $REAL_FOLDER=Resolve-Path -Path "$PSScriptRoot/../${global:FOLDER}"
 
@@ -38,22 +37,22 @@ BuildNcatImage
 
 Describe "[$global:JDK $global:FLAVOR] build image" {
     BeforeAll {
-      Push-Location -StackName 'agent' -Path "$PSScriptRoot/.."
+        Push-Location -StackName 'agent' -Path "$PSScriptRoot/.."
     }
 
     It 'builds image' {
-      $exitCode, $stdout, $stderr = Run-Program 'docker.exe' "build --build-arg VERSION=$global:VERSION -t $global:AGENT_IMAGE $global:FOLDER"
-      $exitCode | Should -Be 0
+        $exitCode, $stdout, $stderr = Run-Program 'docker.exe' "build --tag $global:AGENT_IMAGE --file $global:FOLDER/Dockerfile ./"
+        $exitCode | Should -Be 0
     }
 
     AfterAll {
-      Pop-Location -StackName 'agent'
+        Pop-Location -StackName 'agent'
     }
 }
 
 Describe "[$global:JDK $global:FLAVOR] check default user account" {
     BeforeAll {
-        docker run -d -it --name "$global:AGENT_CONTAINER" -P "$global:AGENT_IMAGE" -Cmd "$global:SHELL"
+        docker run --detach --tty --name "$global:AGENT_CONTAINER" "$global:AGENT_IMAGE" -Cmd "$global:SHELL"
         $LASTEXITCODE | Should -Be 0
         Is-ContainerRunning $global:AGENT_CONTAINER | Should -BeTrue
     }
@@ -75,7 +74,8 @@ Describe "[$global:JDK $global:FLAVOR] check default user account" {
 
 Describe "[$global:JDK $global:FLAVOR] image has jenkins-agent.ps1 in the correct location" {
     BeforeAll {
-        & docker run -dit --name "$global:AGENT_CONTAINER" -P "$global:AGENT_IMAGE" -Cmd $global:SHELL
+        docker run --detach --tty --name "$global:AGENT_CONTAINER" "$global:AGENT_IMAGE" -Cmd "$global:SHELL"
+        $LASTEXITCODE | Should -Be 0
         Is-ContainerRunning $global:AGENT_CONTAINER | Should -BeTrue
     }
 
@@ -95,19 +95,19 @@ Describe "[$global:JDK $global:FLAVOR] image starts jenkins-agent.ps1 correctly 
         # Launch the netcat utility, listening at port 5000 for 30 sec
         # bats will capture the output from netcat and compare the first line
         # of the header of the first HTTP request with the expected one
-        $exitCode, $stdout, $stderr = Run-Program 'docker.exe' "run -dit --name nmap --network=jnlp-network nmap:latest ncat.exe -w 30 -l 5000"
+        $exitCode, $stdout, $stderr = Run-Program 'docker.exe' "run --detach --tty --name nmap --network=jnlp-network nmap:latest ncat.exe -w 30 -l 5000"
         $exitCode | Should -Be 0
         Is-ContainerRunning "nmap" | Should -BeTrue
 
         # get the ip address of the nmap container
-        $exitCode, $stdout, $stderr = Run-Program 'docker.exe' "inspect -f `"{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}`" nmap"
+        $exitCode, $stdout, $stderr = Run-Program 'docker.exe' "inspect --format `"{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}`" nmap"
         $exitCode | Should -Be 0
         $nmap_ip = $stdout.Trim()
 
         # run Jenkins agent which tries to connect to the nmap container at port 5000
         $secret = "aaa"
         $name = "bbb"
-        $exitCode, $stdout, $stderr = Run-Program 'docker.exe' "run -dit --network=jnlp-network --name $global:AGENT_CONTAINER $global:AGENT_IMAGE -Url http://${nmap_ip}:5000 $secret $name"
+        $exitCode, $stdout, $stderr = Run-Program 'docker.exe' "run --detach --tty --network=jnlp-network --name $global:AGENT_CONTAINER $global:AGENT_IMAGE -Url http://${nmap_ip}:5000 $secret $name"
         $exitCode | Should -Be 0
         Is-ContainerRunning $global:AGENT_CONTAINER | Should -BeTrue
 
@@ -139,7 +139,7 @@ Describe "[$global:JDK $global:FLAVOR] build args" {
         $exitCode, $stdout, $stderr = Run-Program 'docker.exe' "build --build-arg version=${ARG_TEST_VERSION} --build-arg user=$TEST_USER -t $global:AGENT_IMAGE $global:FOLDER"
         $exitCode | Should -Be 0
 
-        $exitCode, $stdout, $stderr = Run-Program 'docker.exe' "run -dit --name $global:AGENT_CONTAINER -P $global:AGENT_IMAGE -Cmd $global:SHELL"
+        $exitCode, $stdout, $stderr = Run-Program 'docker.exe' "run --detach --tty --name $global:AGENT_CONTAINER $global:AGENT_IMAGE -Cmd $global:SHELL"
         $exitCode | Should -Be 0
         Is-ContainerRunning "$global:AGENT_CONTAINER" | Should -BeTrue
     }
@@ -172,26 +172,25 @@ Describe "[$global:JDK $global:FLAVOR] build args" {
     }
 }
 
-
 Describe "[$global:JDK $global:FLAVOR] passing JVM options (slow test)" {
     It "shows the java version with --show-version" {
         $exitCode, $stdout, $stderr = Run-Program 'docker.exe' "network create --driver nat jnlp-network"
         # Launch the netcat utility, listening at port 5000 for 30 sec
         # bats will capture the output from netcat and compare the first line
         # of the header of the first HTTP request with the expected one
-        $exitCode, $stdout, $stderr = Run-Program 'docker.exe' "run -dit --name nmap --network=jnlp-network nmap:latest ncat.exe -w 30 -l 5000"
+        $exitCode, $stdout, $stderr = Run-Program 'docker.exe' "run --detach --tty --name nmap --network=jnlp-network nmap:latest ncat.exe -w 30 -l 5000"
         $exitCode | Should -Be 0
         Is-ContainerRunning "nmap" | Should -BeTrue
 
         # get the ip address of the nmap container
-        $exitCode, $stdout, $stderr = Run-Program 'docker.exe' "inspect -f `"{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}`" nmap"
+        $exitCode, $stdout, $stderr = Run-Program 'docker.exe' "inspect --format `"{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}`" nmap"
         $exitCode | Should -Be 0
         $nmap_ip = $stdout.Trim()
 
         # run Jenkins agent which tries to connect to the nmap container at port 5000
         $secret = "aaa"
         $name = "bbb"
-        $exitCode, $stdout, $stderr = Run-Program 'docker.exe' "run -dit --network=jnlp-network --name $global:AGENT_CONTAINER $global:AGENT_IMAGE -Url http://${nmap_ip}:5000 -JenkinsJavaOpts `"--show-version`" $secret $name"
+        $exitCode, $stdout, $stderr = Run-Program 'docker.exe' "run --detach --tty --network=jnlp-network --name $global:AGENT_CONTAINER $global:AGENT_IMAGE -Url http://${nmap_ip}:5000 -JenkinsJavaOpts `"--show-version`" $secret $name"
         $exitCode | Should -Be 0
         Is-ContainerRunning $global:AGENT_CONTAINER | Should -BeTrue
         $exitCode, $stdout, $stderr = Run-Program 'docker.exe' "logs $global:AGENT_CONTAINER"


### PR DESCRIPTION
This PR improves the Windows test harness to:

- Switch `docker` commands to use long from flags: it's easier to read and understand when debugging
- Stop using the `-i / --interactive` flag for `docker.exe run` commands: it's not needed (either the test harness is a script running as a non interactive process, or the containers are run on background which means only `--tty / -t` is required to keep the container running for the subsequent `docker.exe exec` commands
- Remove unused `-P / --publish` port: no port is exposed by the image so no need to publish any port at all (it's inbound protocol, not ssh).


<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
