### PR TITLE
[Windows] Allow JENKINS_URL to not be set when JENKINS_DIRECT_CONNECTION is set

### DIFF
--- a/jenkins-agent.ps1
+++ b/jenkins-agent.ps1
@@ -23,7 +23,7 @@
 [CmdletBinding()]
 Param(
     $Cmd = '', # this must be specified explicitly
-    $Url = $( if([System.String]::IsNullOrWhiteSpace($Cmd) -and [System.String]::IsNullOrWhiteSpace($env:JENKINS_URL)) { throw ("Url is required") } else { '' } ),
+    $Url = $( if([System.String]::IsNullOrWhiteSpace($Cmd) -and [System.String]::IsNullOrWhiteSpace($env:JENKINS_URL) -and [System.String]::IsNullOrWhiteSpace($env:JENKINS_DIRECT_CONNECTION)) { throw ("Url is required") } else { '' } ),
     [Parameter(Position=0)]$Secret = $( if([System.String]::IsNullOrWhiteSpace($Cmd) -and [System.String]::IsNullOrWhiteSpace($env:JENKINS_SECRET)) { throw ("Secret is required") } else { '' } ),
     [Parameter(Position=1)]$Name = $( if([System.String]::IsNullOrWhiteSpace($Cmd) -and [System.String]::IsNullOrWhiteSpace($env:JENKINS_AGENT_NAME)) { throw ("Name is required") } else { '' } ),
     $Tunnel = '',


### PR DESCRIPTION
This fixes #358 by only requiring `JENKINS_URL` have a value when `JENKINS_DIRECT_CONNECTION` is not set as well.

### Testing done

Made the change on my own Jenkins and verified it worked when `JENKINS_URL` is not set but `JENKINS_DIRECT_CONNECTION` is.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```