### PR TITLE
chore(updatecli): track `git` and `git-lfs` versions for Windows images

### DIFF
--- a/updatecli/updatecli.d/git-lfs-windows.yml
+++ b/updatecli/updatecli.d/git-lfs-windows.yml
@@ -1,0 +1,56 @@
+name: Bump `git-lfs` version on Windows
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  lastVersion:
+    kind: githubrelease
+    name: Get the latest `git-lfs` version
+    spec:
+      owner: git-lfs
+      repository: git-lfs
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      versionfilter:
+        kind: semver
+
+targets:
+  setGitLfsVersionWindowsNanoserver2019:
+    name: Update the `git-lfs` Windows version for Windows Nanoserver
+    kind: dockerfile
+    spec:
+      file: windows/nanoserver-1809/Dockerfile
+      instruction:
+        keyword: ARG
+        matcher: GIT_LFS_VERSION
+    scmid: default
+  setGitLfsVersionWindowsServer2019:
+    name: Update the `git-lfs` Windows version for Windows Server Core
+    kind: dockerfile
+    spec:
+      file: windows/windowsservercore-ltsc2019/Dockerfile
+      instruction:
+        keyword: ARG
+        matcher: GIT_LFS_VERSION
+    scmid: default
+
+actions:
+  default:
+    kind: github/pullrequest
+    title: Bump `git-lfs` version on Windows images to {{ source "lastVersion" }}
+    scmid: default
+    spec:
+      labels:
+        - enhancement
+        - git-lfs
+        - windows

--- a/updatecli/updatecli.d/git-windows.yml
+++ b/updatecli/updatecli.d/git-windows.yml
@@ -1,0 +1,95 @@
+---
+name: Bump Git version on Windows
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  lastVersion:
+    kind: githubrelease
+    name: Get the latest Git version
+    spec:
+      owner: "git-for-windows"
+      repository: "git"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      versionfilter:
+        kind: regex
+        ## Latest stable v{x.y.z}.windows.<patch>
+        pattern: 'v(\d*)\.(\d*)\.(\d*)\.windows\.(\d*)$'
+    transformers:
+      - trimprefix: "v"
+
+targets:
+  setGitVersionWindowsNanoserver:
+    name: Update the Git Windows version for Windows Nanoserver
+    transformers:
+      - findsubmatch:
+          pattern: '(.*).windows\.(\d*)$'
+          captureindex: 1
+    kind: dockerfile
+    spec:
+      file: windows/nanoserver-1809/Dockerfile
+      instruction:
+        keyword: ARG
+        matcher: GIT_VERSION
+    scmid: default
+  setGitVersionWindowsServerCore:
+    name: Update the Git Windows version for Windows Server Core
+    transformers:
+      - findsubmatch:
+          pattern: '(.*).windows\.(\d*)$'
+          captureindex: 1
+    kind: dockerfile
+    spec:
+      file: windows/windowsservercore-ltsc2019/Dockerfile
+      instruction:
+        keyword: ARG
+        matcher: GIT_VERSION
+    scmid: default
+  setGitPackagePatchWindowsNanoserver:
+    name: Update the Git Package Windows patch for Windows Nanoserver
+    transformers:
+      - findsubmatch:
+          pattern: '(.*).windows\.(\d*)$'
+          captureindex: 2
+    kind: dockerfile
+    spec:
+      file: windows/nanoserver-1809/Dockerfile
+      instruction:
+        keyword: ARG
+        matcher: GIT_PATCH_VERSION
+    scmid: default
+  setGitPackagePatchWindowsServerCore:
+    name: Update the Git Package Windows patch for Windows Server Core
+    transformers:
+      - findsubmatch:
+          pattern: '(.*).windows\.(\d*)$'
+          captureindex: 2
+    kind: dockerfile
+    spec:
+      file: windows/windowsservercore-ltsc2019/Dockerfile
+      instruction:
+        keyword: ARG
+        matcher: GIT_PATCH_VERSION
+    scmid: default
+
+actions:
+  default:
+    kind: github/pullrequest
+    title: Bump Git version on Windows to {{ source "lastVersion" }}
+    scmid: default
+    spec:
+      labels:
+        - enhancement
+        - git
+        - windows


### PR DESCRIPTION
This PR adds updatecli manifests to track `git` and `git-lfs` versions for Windows images like what is done in https://github.com/jenkinsci/docker-ssh-agent/

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
