### PR TITLE
chore: show `JAVA_MAJOR_VERSION` in tests output

### DIFF
--- a/tests/inboundAgent.Tests.ps1
+++ b/tests/inboundAgent.Tests.ps1
@@ -145,7 +145,7 @@ Describe "[$global:AGENT_IMAGE] custom build args" {
 }
 
 Describe "[$global:AGENT_IMAGE] passing JVM options (slow test)" {
-    It "shows the java version with --show-version" {
+    It "shows the java version ${global:JAVA_MAJOR_VERSION} with --show-version" {
         $exitCode, $stdout, $stderr = Run-Program 'docker' "network create --driver nat jnlp-network"
         # Launch the netcat utility, listening at port 5000 for 30 sec
         # bats will capture the output from netcat and compare the first line


### PR DESCRIPTION
This PR outputs `JAVA_MAJOR_VERSION` environment variable in tests logs (Quality of Life).

Extract from #374 

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
