### PR TITLE
fixup(Jenkinsfile) use simple quotes for `powershell` steps

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -51,7 +51,7 @@ pipeline {
                                             // If the tests are passing for Linux AMD64, then we can build all the CPU architectures
                                             sh 'docker buildx bake --file docker-bake.hcl linux'
                                         } else {
-                                            powershell "& ./build.ps1 test"
+                                            powershell '& ./build.ps1 test'
                                         }
                                     }
                                 }
@@ -76,7 +76,7 @@ pipeline {
                                                 docker buildx bake --push --file docker-bake.hcl linux
                                                 '''
                                             } else {
-                                                powershell "& ./build.ps1 -PushVersions -VersionTag $env:TAG_NAME publish"
+                                                powershell '& ./build.ps1 -PushVersions -VersionTag $env:TAG_NAME publish'
                                             }
                                         }
                                     }


### PR DESCRIPTION
This PR fixes the error:

```
jenkins/inbound-agent:org.jenkinsci.plugins.workflow.cps.EnvActionImpl@3c0440bb:TAG_NAME-windowsservercore-ltsc2022
```

