### PR TITLE
fix: correct Windows images tags

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -215,7 +215,7 @@ if($target -eq "publish") {
             }
 
             if($PushVersions) {
-                $buildTag = "$VersionTag-$tag"
+                $buildTag = "$tag"
                 if($tag -eq 'latest') {
                     $buildTag = "$VersionTag"
                 }
@@ -234,7 +234,7 @@ if($target -eq "publish") {
                 }
 
                 if($PushVersions) {
-                    $buildTag = "$VersionTag-$tag"
+                    $buildTag = "$tag"
                     if($tag -eq 'latest') {
                         $buildTag = "$VersionTag"
                     }


### PR DESCRIPTION
This PR fixes the Windows images tags, as there are currently unwanted ones with duplicated parent image version:
> 3131.vf2b_b_798b_ce99-5-3131.vf2b_b_798b_ce99-5-jdk11-nanoserver-1809

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
