### PR TITLE
Sync README.md with docker hub

### DIFF
--- a/.github/workflows/sync-dockerhub-readme.yaml
+++ b/.github/workflows/sync-dockerhub-readme.yaml
@@ -1,8 +1,7 @@
 name: Update Docker Hub Description
 on:
-  on:
-    release:
-      types: [ published ]
+  release:
+    types: [ published ]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/sync-dockerhub-readme.yaml
+++ b/.github/workflows/sync-dockerhub-readme.yaml
@@ -1,11 +1,8 @@
 name: Update Docker Hub Description
 on:
-  push:
-    branches:
-      - master
-    paths:
-      - README.md
-      - .github/workflows/sync-dockerhub-readme.yaml
+  on:
+    release:
+      types: [ published ]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/sync-dockerhub-readme.yaml
+++ b/.github/workflows/sync-dockerhub-readme.yaml
@@ -1,0 +1,23 @@
+name: Update Docker Hub Description
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - README.md
+      - .github/workflows/sync-dockerhub-readme.yaml
+  workflow_dispatch:
+
+jobs:
+  dockerHubDescription:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Update Docker Hub description
+        uses: peter-evans/dockerhub-description@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          enable-url-completion: true
+          short-description: ${{ github.event.repository.description }}
+          repository: jenkins/inbound-agent


### PR DESCRIPTION
Recently, @timja updated the readmes of a few repositories on docker hub, to be up-to-date. The change proposed keeps their presence in sync with what's used on GitHub.

Depending on the seats available, we could add a machine account, or one of the docker hub admins would need to create a PAT and add that as secret. Keep the token in mind, we could reuse it in other repositories too.

I did a quick demo earlier with https://github.com/NotMyFault/dockerhub-sync-em pushing to https://hub.docker.com/r/notmyfault1/sync-demo to ensure the presence looks as intended with our formatting.