### PR TITLE
Fix incorrect link for using agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ These images are deprecated, use [jenkins/inbound-agent](https://hub.docker.com/
 This is an image for [Jenkins](https://jenkins.io) agents using TCP or WebSockets to establish inbound connection to the Jenkins master.
 This agent is powered by the [Jenkins Remoting library](https://github.com/jenkinsci/remoting), which version is being taken from the base [Docker Agent](https://github.com/jenkinsci/docker-agent/) image.
 
-See [Jenkins Distributed builds](https://wiki.jenkins-ci.org/display/JENKINS/Distributed+builds) for more info.
+See [Using Agents](https://www.jenkins.io/doc/book/using/using-agents/) for more info.
 
 ## Running
 


### PR DESCRIPTION
Changes link that was pointing to the wiki to point to the documentation on jenkins.io.

### Testing done

No testing done

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

