### PR TITLE
chore(updatecli) track docker-bake.hcl variables with the HCL resource instead of file resource

### DIFF
--- a/updatecli/updatecli.d/docker-agent.yaml
+++ b/updatecli/updatecli.d/docker-agent.yaml
@@ -138,13 +138,10 @@ targets:
     scmid: default
   setDockerBakeDefaultParentImage:
     name: Bump the parent image `jenkins/agent` version on the docker-bake.hcl file
-    kind: file
+    kind: hcl
     spec:
       file: docker-bake.hcl
-      matchpattern: >-
-        variable(.*)"PARENT_IMAGE_VERSION"(.*){(.*)(\r\n|\r|\n)(.*)default(.*)=(.*)
-      replacepattern: >-
-        variable${1}"PARENT_IMAGE_VERSION"${2}{${3}${4}${5}default${6}= "{{ source "lastVersion" }}"
+      path: variable.PARENT_IMAGE_VERSION.default
     scmid: default
   setWindowsBuildPwshParentImage:
     name: Bump the parent image `jenkins/agent` version on the Windows build.ps1 powershell script


### PR DESCRIPTION
Since [0.55.0](https://github.com/updatecli/updatecli/releases/tag/v0.55.0), updatecli has a [native HCL resource](https://www.updatecli.io/docs/plugins/resource/hcl/).

This PR updates the manifest to replace the tedious "file resource with matchpattern regex" in favor of the native HCL.