### PR TITLE
feat(jdk): Add preview images for jdk21

### DIFF
--- a/alpine/Dockerfile-jdk21
+++ b/alpine/Dockerfile-jdk21
@@ -1,0 +1,35 @@
+# The MIT License
+#
+#  Copyright (c) 2015-2020, CloudBees, Inc. and other Jenkins contributors
+#
+#  Permission is hereby granted, free of charge, to any person obtaining a copy
+#  of this software and associated documentation files (the "Software"), to deal
+#  in the Software without restriction, including without limitation the rights
+#  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+#  copies of the Software, and to permit persons to whom the Software is
+#  furnished to do so, subject to the following conditions:
+#
+#  The above copyright notice and this permission notice shall be included in
+#  all copies or substantial portions of the Software.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+#  THE SOFTWARE.
+
+ARG version=3148.v532a_7e715ee3-1
+ARG JAVA_MAJOR_VERSION=21
+FROM jenkins/agent:"${version}"-alpine-jdk"${JAVA_MAJOR_VERSION}"-preview
+
+ARG user=jenkins
+
+USER root
+COPY ../../jenkins-agent /usr/local/bin/jenkins-agent
+RUN chmod +x /usr/local/bin/jenkins-agent &&\
+    ln -s /usr/local/bin/jenkins-agent /usr/local/bin/jenkins-slave
+USER ${user}
+
+ENTRYPOINT ["/usr/local/bin/jenkins-agent"]

--- a/debian/Dockerfile-jdk21
+++ b/debian/Dockerfile-jdk21
@@ -1,5 +1,5 @@
 ARG version=3148.v532a_7e715ee3-1
-ARG JAVA_MAJOR_VERSION=17
+ARG JAVA_MAJOR_VERSION=21
 FROM jenkins/agent:"${version}"-jdk"${JAVA_MAJOR_VERSION}-preview"
 
 ARG user=jenkins

--- a/debian/Dockerfile-jdk21
+++ b/debian/Dockerfile-jdk21
@@ -1,0 +1,13 @@
+ARG version=3148.v532a_7e715ee3-1
+ARG JAVA_MAJOR_VERSION=17
+FROM jenkins/agent:"${version}"-jdk"${JAVA_MAJOR_VERSION}-preview"
+
+ARG user=jenkins
+
+USER root
+COPY ../../jenkins-agent /usr/local/bin/jenkins-agent
+RUN chmod +x /usr/local/bin/jenkins-agent &&\
+    ln -s /usr/local/bin/jenkins-agent /usr/local/bin/jenkins-slave
+USER ${user}
+
+ENTRYPOINT ["/usr/local/bin/jenkins-agent"]

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -11,6 +11,7 @@ group "linux-arm64" {
   targets = [
     "debian_jdk11",
     "debian_jdk17",
+    "alpine_jdk21",
   ]
 }
 
@@ -78,6 +79,21 @@ target "alpine_jdk17" {
     "${REGISTRY}/${JENKINS_REPO}:latest-alpine-jdk17",
   ]
   platforms = ["linux/amd64"]
+}
+
+target "alpine_jdk21" {
+  dockerfile = "alpine/Dockerfile"
+  context = "."
+  args = {
+    JAVA_MAJOR_VERSION = "21"
+    version = "${PARENT_IMAGE_VERSION}"
+  }
+  tags = [
+    equal(ON_TAG, "true") ? "${REGISTRY}/${JENKINS_REPO}:${PARENT_IMAGE_VERSION}-alpine-jdk21": "",
+    "${REGISTRY}/${JENKINS_REPO}:alpine-jdk21",
+    "${REGISTRY}/${JENKINS_REPO}:latest-alpine-jdk21",
+  ]
+  platforms = ["linux/amd64, linux/arm64"]
 }
 
 target "debian_jdk11" {

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -5,6 +5,7 @@ group "linux" {
     "alpine_jdk21",
     "debian_jdk11",
     "debian_jdk17",
+    "debian_jdk21",
   ]
 }
 
@@ -12,6 +13,7 @@ group "linux-arm64" {
   targets = [
     "debian_jdk11",
     "debian_jdk17",
+    "debian_jdk21",
     "alpine_jdk21",
   ]
 }
@@ -90,9 +92,9 @@ target "alpine_jdk21" {
     version = "${PARENT_IMAGE_VERSION}"
   }
   tags = [
-    equal(ON_TAG, "true") ? "${REGISTRY}/${JENKINS_REPO}:${PARENT_IMAGE_VERSION}-alpine-jdk21": "",
-    "${REGISTRY}/${JENKINS_REPO}:alpine-jdk21",
-    "${REGISTRY}/${JENKINS_REPO}:latest-alpine-jdk21",
+    equal(ON_TAG, "true") ? "${REGISTRY}/${JENKINS_REPO}:${PARENT_IMAGE_VERSION}-alpine-jdk21-preview": "",
+    "${REGISTRY}/${JENKINS_REPO}:alpine-jdk21-preview",
+    "${REGISTRY}/${JENKINS_REPO}:latest-alpine-jdk21-preview",
   ]
   platforms = ["linux/amd64", "linux/arm64"]
 }
@@ -127,4 +129,19 @@ target "debian_jdk17" {
     "${REGISTRY}/${JENKINS_REPO}:latest-jdk17",
   ]
   platforms = ["linux/amd64", "linux/arm64", "linux/arm/v7", "linux/ppc64le"]
+}
+
+target "debian_jdk21" {
+  dockerfile = "debian/Dockerfile-jdk21"
+  context = "."
+  args = {
+    JAVA_MAJOR_VERSION = "21"
+    version = "${PARENT_IMAGE_VERSION}"
+  }
+  tags = [
+    equal(ON_TAG, "true") ? "${REGISTRY}/${JENKINS_REPO}:${PARENT_IMAGE_VERSION}-jdk21-preview": "",
+    "${REGISTRY}/${JENKINS_REPO}:jdk21-preview",
+    "${REGISTRY}/${JENKINS_REPO}:latest-jdk21-preview",
+  ]
+  platforms = ["linux/amd64", "linux/arm64"]
 }

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -2,6 +2,7 @@ group "linux" {
   targets = [
     "alpine_jdk11",
     "alpine_jdk17",
+    "alpine_jdk21",
     "debian_jdk11",
     "debian_jdk17",
   ]
@@ -33,7 +34,7 @@ variable "IMAGE_TAG" {
 
 #### This is for the "parent" image version to use (jenkins/agent:<PARENT_IMAGE_VERSION>-<base-os>)
 variable "PARENT_IMAGE_VERSION" {
-  default = "3148.v532a_7e715ee3-1"
+  default = "3148.v532a_7e715ee3-4"
 }
 
 variable "REGISTRY" {
@@ -82,7 +83,7 @@ target "alpine_jdk17" {
 }
 
 target "alpine_jdk21" {
-  dockerfile = "alpine/Dockerfile"
+  dockerfile = "alpine/Dockerfile-jdk21"
   context = "."
   args = {
     JAVA_MAJOR_VERSION = "21"
@@ -93,7 +94,7 @@ target "alpine_jdk21" {
     "${REGISTRY}/${JENKINS_REPO}:alpine-jdk21",
     "${REGISTRY}/${JENKINS_REPO}:latest-alpine-jdk21",
   ]
-  platforms = ["linux/amd64, linux/arm64"]
+  platforms = ["linux/amd64", "linux/arm64"]
 }
 
 target "debian_jdk11" {

--- a/tests/tests.bats
+++ b/tests/tests.bats
@@ -49,7 +49,7 @@ SUT_IMAGE="$(get_sut_image)"
 
   # Old version used to test overriding the build arguments.
   # This old version must have the same tag suffixes as the ones defined in the docker-bake file (`-jdk17`, `jdk11`, etc.)
-  TEST_VERSION="3148.v532a_7e715ee3-4"
+  TEST_VERSION="3148.v532a_7e715ee3"
   PARENT_IMAGE_VERSION_SUFFIX="4"
 
   ARG_TEST_VERSION="${TEST_VERSION}-${PARENT_IMAGE_VERSION_SUFFIX}"

--- a/tests/tests.bats
+++ b/tests/tests.bats
@@ -49,7 +49,7 @@ SUT_IMAGE="$(get_sut_image)"
 
   # Old version used to test overriding the build arguments.
   # This old version must have the same tag suffixes as the ones defined in the docker-bake file (`-jdk17`, `jdk11`, etc.)
-  TEST_VERSION="3131.vf2b_b_798b_ce99"
+  TEST_VERSION="3148.v532a_7e715ee3-4"
   PARENT_IMAGE_VERSION_SUFFIX="4"
 
   ARG_TEST_VERSION="${TEST_VERSION}-${PARENT_IMAGE_VERSION_SUFFIX}"


### PR DESCRIPTION
This is something that was discussed in #395 .
This work follows the issue and PR brought by @nbr23.
I had to modify `TEST_VERSION="3148.v532a_7e715ee3"` in `tests.bats` because there is no `3131xxx` version for JDK21.
The first JDK21-compatible version is `3148.v532a_7e715ee3`.

### Testing done

```
 make build-debian_jdk21
 make build-alpine_jdk21
```

### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue