### PR TITLE
chore(updatecli) fix platform syntax for armv7 (edge case)

### DIFF
--- a/updatecli/updatecli.d/docker-agent.yaml
+++ b/updatecli/updatecli.d/docker-agent.yaml
@@ -60,7 +60,7 @@ conditions:
       architectures:
         - amd64
         - arm64
-        - arm/v7
+        - linux/arm/v7
         - s390x
         - ppc64le
       image: jenkins/agent
@@ -73,7 +73,7 @@ conditions:
       architectures:
         - amd64
         - arm64
-        - arm/v7
+        - linux/arm/v7
       image: jenkins/agent
       tag: '{{source "lastVersion" }}-jdk17'
   checkJdk21DebianDockerImages:


### PR DESCRIPTION
We are hitting an edge case of the Docker internal platform representation with updatecli.

Consequence is, until this PR is merged, we won't have an automated update of the parent image because the automated process fails the condition for Debian armv7 images checks.

This PR is blocked by #411 (to allow creating an intermediate release).

Once #411 is merged, then we can merge here.

The expected result is to have an automated PR proposing to bump to the `3148.v532a_7e715ee3-9` version.