### PR TITLE
Remove usage of deprecated `-headless` argument

### DIFF
--- a/jenkins-agent
+++ b/jenkins-agent
@@ -128,6 +128,6 @@ else
 	#TODO: Handle the case when the command-line and Environment variable contain different values.
 	#It is fine it blows up for now since it should lead to an error anyway.
 
-        exec $JAVA_BIN $JAVA_OPTIONS -cp /usr/share/jenkins/agent.jar hudson.remoting.jnlp.Main -headless $TUNNEL $URL $WORKDIR $WEB_SOCKET $DIRECT $PROTOCOLS $INSTANCE_IDENTITY $OPT_JENKINS_SECRET $OPT_JENKINS_AGENT_NAME "$@"
+        exec $JAVA_BIN $JAVA_OPTIONS -cp /usr/share/jenkins/agent.jar hudson.remoting.jnlp.Main $TUNNEL $URL $WORKDIR $WEB_SOCKET $DIRECT $PROTOCOLS $INSTANCE_IDENTITY $OPT_JENKINS_SECRET $OPT_JENKINS_AGENT_NAME "$@"
 
 fi

--- a/jenkins-agent.ps1
+++ b/jenkins-agent.ps1
@@ -104,7 +104,7 @@ if(![System.String]::IsNullOrWhiteSpace($Cmd)) {
         $AgentArguments += Invoke-Expression "echo $JenkinsJavaOpts"
     }
 
-    $AgentArguments += @("-cp", "C:/ProgramData/Jenkins/agent.jar", "hudson.remoting.jnlp.Main", "-headless")
+    $AgentArguments += @("-cp", "C:/ProgramData/Jenkins/agent.jar", "hudson.remoting.jnlp.Main")
 
     if(![System.String]::IsNullOrWhiteSpace($Tunnel)) {
         $AgentArguments += @("-tunnel", "`"$Tunnel`"")


### PR DESCRIPTION
This argument has been deprecated since jenkinsci/remoting#532 and is a no-op. We should stop passing it in.

### Testing done

The CI build should be sufficient I think.