### PR TITLE
fix(updatecli): check preview parent images only for some architectures

### DIFF
--- a/updatecli/updatecli.d/docker-agent.yaml
+++ b/updatecli/updatecli.d/docker-agent.yaml
@@ -44,17 +44,17 @@ conditions:
       tag: '{{source "lastVersion" }}-alpine-jdk17'
   checkJdk21AlpineDockerImage:
     kind: dockerimage
-    name: Check if the container image "jenkins/agent:<lastVersion>-alpine-jdk21-preview" for linux/amd64 is available
+    name: Check if the container image "jenkins/agent:<lastVersion>-alpine-jdk21" for linux/amd64 is available
     disablesourceinput: true
     spec:
       architectures:
         - amd64
         - arm64
       image: jenkins/agent
-      tag: '{{source "lastVersion" }}-alpine-jdk21-preview'
+      tag: '{{source "lastVersion" }}-alpine-jdk21'
   checkJdk11DebianDockerImages:
     kind: dockerimage
-    name: Check if the container image "jenkins/agent:<lastVersion>-jdk11" for linux/amd64 is available
+    name: Check if the container image "jenkins/agent:<lastVersion>-jdk11" for linux/amd64, linux/arm64, linux/arm/v7, s390x and ppc64le is available
     disablesourceinput: true
     spec:
       architectures:
@@ -67,7 +67,7 @@ conditions:
       tag: '{{source "lastVersion" }}-jdk11'
   checkJdk17DebianDockerImages:
     kind: dockerimage
-    name: Check if the container image "jenkins/agent:<lastVersion>-jdk17" for linux/amd64 is available
+    name: Check if the container image "jenkins/agent:<lastVersion>-jdk17" for linux/amd64, linux/arm64 & linux/arm/v7 is available
     disablesourceinput: true
     spec:
       architectures:
@@ -78,12 +78,21 @@ conditions:
       tag: '{{source "lastVersion" }}-jdk17'
   checkJdk21DebianDockerImages:
     kind: dockerimage
-    name: Check if the container image "jenkins/agent:<lastVersion>-jdk21-preview" for linux/amd64 is available
+    name: Check if the container image "jenkins/agent:<lastVersion>-jdk21-preview" for linux/amd64 & linux/arm64 is available
     disablesourceinput: true
     spec:
       architectures:
         - amd64
         - arm64
+      image: jenkins/agent
+      tag: '{{source "lastVersion" }}-jdk21'
+  checkJdk21DebianPreviewDockerImages:
+    kind: dockerimage
+    name: Check if the container image "jenkins/agent:<lastVersion>-jdk21-preview" for ppc64le is available
+    disablesourceinput: true
+    spec:
+      architectures:
+        - ppc64le
       image: jenkins/agent
       tag: '{{source "lastVersion" }}-jdk21-preview'
   checkJdk11WindowsNanoserver1809DockerImage:

--- a/updatecli/updatecli.d/docker-agent.yaml
+++ b/updatecli/updatecli.d/docker-agent.yaml
@@ -88,11 +88,13 @@ conditions:
       tag: '{{source "lastVersion" }}-jdk21'
   checkJdk21DebianPreviewDockerImages:
     kind: dockerimage
-    name: Check if the container image "jenkins/agent:<lastVersion>-jdk21-preview" for ppc64le is available
+    name: Check if the container image "jenkins/agent:<lastVersion>-jdk21-preview" for ppc64le, linux/arm/v7 and s390x is available
     disablesourceinput: true
     spec:
       architectures:
         - ppc64le
+        - linux/arm/v7
+        - s390x
       image: jenkins/agent
       tag: '{{source "lastVersion" }}-jdk21-preview'
   checkJdk11WindowsNanoserver1809DockerImage:


### PR DESCRIPTION
This PR fixes the docker-agent updatecli manifest to check the existence of preview images only for some architectures.

Follow-up of https://github.com/jenkinsci/docker-agent/pull/521

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
