### PR TITLE
Migrate to new Remoting calling convention

### DIFF
--- a/jenkins-agent
+++ b/jenkins-agent
@@ -22,7 +22,7 @@
 #  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 #  THE SOFTWARE.
 
-# Usage jenkins-agent.sh [options] -url http://jenkins [SECRET] [AGENT_NAME]
+# Usage jenkins-agent.sh [options] -url http://jenkins -secret [SECRET] -name [AGENT_NAME]
 # Optional environment variables :
 # * JENKINS_JAVA_BIN : Java executable to use instead of the default in PATH or obtained from JAVA_HOME
 # * JENKINS_JAVA_OPTS : Java Options to use for the remoting process, otherwise obtained from JAVA_OPTS
@@ -107,27 +107,25 @@ else
 	fi
 
 	# if both required options are defined, do not pass the parameters
-	OPT_JENKINS_SECRET=""
 	if [ -n "$JENKINS_SECRET" ]; then
 		case "$@" in
 			*"${JENKINS_SECRET}"*) echo "Warning: SECRET is defined twice in command-line arguments and the environment variable" ;;
 			*)
-			OPT_JENKINS_SECRET="${JENKINS_SECRET}" ;;
+			SECRET="-secret ${JENKINS_SECRET}" ;;
 		esac
 	fi
 	
-	OPT_JENKINS_AGENT_NAME=""
 	if [ -n "$JENKINS_AGENT_NAME" ]; then
 		case "$@" in
 			*"${JENKINS_AGENT_NAME}"*) echo "Warning: AGENT_NAME is defined twice in command-line arguments and the environment variable" ;;
 			*)
-			OPT_JENKINS_AGENT_NAME="${JENKINS_AGENT_NAME}" ;;
+			AGENT_NAME="-name ${JENKINS_AGENT_NAME}" ;;
 		esac
 	fi
 
 	#TODO: Handle the case when the command-line and Environment variable contain different values.
 	#It is fine it blows up for now since it should lead to an error anyway.
 
-        exec $JAVA_BIN $JAVA_OPTIONS -cp /usr/share/jenkins/agent.jar hudson.remoting.jnlp.Main $TUNNEL $URL $WORKDIR $WEB_SOCKET $DIRECT $PROTOCOLS $INSTANCE_IDENTITY $OPT_JENKINS_SECRET $OPT_JENKINS_AGENT_NAME "$@"
+        exec $JAVA_BIN $JAVA_OPTIONS -jar /usr/share/jenkins/agent.jar $SECRET $AGENT_NAME $TUNNEL $URL $WORKDIR $WEB_SOCKET $DIRECT $PROTOCOLS $INSTANCE_IDENTITY "$@"
 
 fi

--- a/jenkins-agent.ps1
+++ b/jenkins-agent.ps1
@@ -104,7 +104,9 @@ if(![System.String]::IsNullOrWhiteSpace($Cmd)) {
         $AgentArguments += Invoke-Expression "echo $JenkinsJavaOpts"
     }
 
-    $AgentArguments += @("-cp", "C:/ProgramData/Jenkins/agent.jar", "hudson.remoting.jnlp.Main")
+    $AgentArguments += @("-jar", "C:/ProgramData/Jenkins/agent.jar")
+    $AgentArguments += @("-secret", $Secret)
+    $AgentArguments += @("-name", $Name)
 
     if(![System.String]::IsNullOrWhiteSpace($Tunnel)) {
         $AgentArguments += @("-tunnel", "`"$Tunnel`"")
@@ -135,10 +137,6 @@ if(![System.String]::IsNullOrWhiteSpace($Cmd)) {
     if(![System.String]::IsNullOrWhiteSpace($Protocols)) {
         $AgentArguments += @('-protocols', $Protocols)
     }
-
-    # these need to be the last things added since they are positional
-    # parameters to agent.jar
-    $AgentArguments += @($Secret, $Name)
 
     if(![System.String]::IsNullOrWhiteSpace($JenkinsJavaBin)) {
         $JAVA_BIN = $JenkinsJavaBin


### PR DESCRIPTION
Migrates from the deprecated `-cp hudson.remoting.jnlp.Main` to the non-deprecated `-jar` usage and from the deprecated positional arguments to the non-deprecated `-secret` and `-name` parameters.

### Implementation notes for reviewers

I stopped defining `OPT_XYZ` to the empty string because the other code in the same file that defined named arguments didn't initialize the variables either, and I wanted to be consistent with the existing code.

### Testing done

I tested the Linux script manually replacing the `exec` with an `echo` to observe various combinations of parameters:

- Secret and name passed in as environment variables and not in arguments
- Secret and name passed in as both environment variables and as (deprecated) positional arguments
- Secret and name passed in as both environment variables and as (non-deprecated) named arguments

All cases were handled correctly.

I'll rely on the CI build to test the Windows changes.