### PR TITLE
chore(updatecli) add missing condition check for `jdk21-nanoserver-ltsc2019` image

### DIFF
--- a/updatecli/updatecli.d/docker-agent.yaml
+++ b/updatecli/updatecli.d/docker-agent.yaml
@@ -145,6 +145,14 @@ conditions:
       architecture: amd64
       image: jenkins/agent
       tag: '{{source "lastVersion" }}-jdk21-windowsservercore-ltsc2019'
+  checkJdk21Nanoserver2019DockerImage:
+    kind: dockerimage
+    name: Check if the container image "jenkins/agent:<lastVersion>-jdk21-nanoserver-ltsc2019" for windows/amd64 is available
+    disablesourceinput: true
+    spec:
+      architecture: amd64
+      image: jenkins/agent
+      tag: '{{source "lastVersion" }}-jdk21-nanoserver-ltsc2019'
 
 targets:
   setAlpineDockerImage:


### PR DESCRIPTION
https://github.com/jenkinsci/docker-inbound-agent/pull/462 was opened while there was a missing image resulting in a failed build